### PR TITLE
Add verbose option for verbose output to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ models = [
 
 timex_datalink_client = TimexDatalinkClient.new(
   serial_device: "/dev/ttyACM0",
-  models: models
+  models: models,
+  verbose: true
 )
 
 timex_datalink_client.write

--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -17,11 +17,12 @@ require "timex_datalink_client/version"
 require "timex_datalink_client/wrist_app"
 
 class TimexDatalinkClient
-  attr_accessor :serial_device, :models
+  attr_accessor :serial_device, :models, :verbose
 
-  def initialize(serial_device:, models: [])
+  def initialize(serial_device:, models: [], verbose: false)
     @serial_device = serial_device
     @models = models
+    @verbose = verbose
   end
 
   def write
@@ -35,6 +36,9 @@ class TimexDatalinkClient
   private
 
   def notebook_adapter
-    @notebook_adapter ||= NotebookAdapter.new(serial_device)
+    @notebook_adapter ||= NotebookAdapter.new(
+      serial_device: serial_device,
+      verbose: verbose
+    )
   end
 end

--- a/lib/timex_datalink_client/notebook_adapter.rb
+++ b/lib/timex_datalink_client/notebook_adapter.rb
@@ -7,21 +7,26 @@ class TimexDatalinkClient
     BYTE_SLEEP = 0.025
     PACKET_SLEEP = 0.25
 
-    attr_accessor :serial_device
+    attr_accessor :serial_device, :verbose
 
-    def initialize(serial_device)
+    def initialize(serial_device:, verbose: false)
       @serial_device = serial_device
+      @verbose = verbose
     end
 
     def write(packets)
       packets.each do |packet|
         packet.each do |byte|
+          printf("%.2X ", byte) if verbose
+
           serial.write(byte.chr)
 
           sleep(BYTE_SLEEP)
         end
 
         sleep(PACKET_SLEEP)
+
+        puts if verbose
       end
     end
 

--- a/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
+++ b/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
@@ -39,7 +39,8 @@ describe TimexDatalinkClient::NotebookAdapter do
     end
 
     it "does not write to console" do
-      allow_any_instance_of(Serial).to receive(:write)
+      allow(Serial).to receive(:new).with(serial_device).and_return(serial_double)
+      allow(serial_double).to receive(:write)
       allow(notebook_adapter).to receive(:sleep)
 
       expect(notebook_adapter).to_not receive(:printf)

--- a/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
+++ b/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
@@ -4,7 +4,14 @@ require "spec_helper"
 
 describe TimexDatalinkClient::NotebookAdapter do
   let(:serial_device) { "/dev/ttyACM0" }
-  subject(:notebook_adapter) { described_class.new(serial_device) }
+  let(:verbose) { false }
+
+  subject(:notebook_adapter) do
+    described_class.new(
+      serial_device: serial_device,
+      verbose: verbose
+    )
+  end
 
   describe "#write" do
     let(:packets) do
@@ -19,9 +26,9 @@ describe TimexDatalinkClient::NotebookAdapter do
     it "writes serial data with correct sleep lengths" do
       expect(Serial).to receive(:new).with(serial_device).and_return(serial_double)
 
-      ["\x00\x01\x02", "\x03\x04\x05"].each do |packet|
-        packet.each_char do |char|
-          expect(serial_double).to receive(:write).with(char).ordered
+      packets.each do |packet|
+        packet.each do |byte|
+          expect(serial_double).to receive(:write).with(byte.chr).ordered
           expect(notebook_adapter).to receive(:sleep).with(0.025).ordered
         end
 
@@ -29,6 +36,37 @@ describe TimexDatalinkClient::NotebookAdapter do
       end
 
       notebook_adapter.write(packets)
+    end
+
+    it "does not write to console" do
+      allow_any_instance_of(Serial).to receive(:write)
+      allow(notebook_adapter).to receive(:sleep)
+
+      expect(notebook_adapter).to_not receive(:printf)
+      expect(notebook_adapter).to_not receive(:puts)
+
+      notebook_adapter.write(packets)
+    end
+
+    context "when verbose is true" do
+      let(:verbose) { true }
+
+      it "writes serial data with correct sleep lengths and console output" do
+        expect(Serial).to receive(:new).with(serial_device).and_return(serial_double)
+
+        packets.each do |packet|
+          packet.each do |byte|
+            expect(notebook_adapter).to receive(:printf).with("%.2X ", byte).ordered
+            expect(serial_double).to receive(:write).with(byte.chr).ordered
+            expect(notebook_adapter).to receive(:sleep).with(0.025).ordered
+          end
+
+          expect(notebook_adapter).to receive(:sleep).with(0.25).ordered
+          expect(notebook_adapter).to receive(:puts).ordered
+        end
+
+        notebook_adapter.write(packets)
+      end
     end
   end
 end

--- a/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
+++ b/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe TimexDatalinkClient::NotebookAdapter do
-  let(:serial_device) { "/dev/ttyACM0" }
+  let(:serial_device) { "/some/serial/device" }
   let(:verbose) { false }
 
   subject(:notebook_adapter) do

--- a/spec/lib/timex_datalink_client_spec.rb
+++ b/spec/lib/timex_datalink_client_spec.rb
@@ -6,6 +6,7 @@ require "spec_helper"
 
 describe TimexDatalinkClient do
   let(:serial_device) { "/dev/ttyACM0" }
+  let(:verbose) { false }
 
   let(:models) do
     [
@@ -33,7 +34,8 @@ describe TimexDatalinkClient do
   let(:timex_datalink_client) do
     described_class.new(
       serial_device: serial_device,
-      models: models
+      models: models,
+      verbose: verbose
     )
   end
 
@@ -74,8 +76,12 @@ describe TimexDatalinkClient do
     subject(:write) { timex_datalink_client.write }
 
     it "passes the correct serial device to NotebookAdapter#new" do
-      expect(TimexDatalinkClient::NotebookAdapter).to receive(:new).with(serial_device).and_return(notebook_adapter_double)
       allow(notebook_adapter_double).to receive(:write)
+
+      expect(TimexDatalinkClient::NotebookAdapter).to receive(:new).with(
+        serial_device: serial_device,
+        verbose: verbose
+      ).and_return(notebook_adapter_double)
 
       write
     end

--- a/spec/lib/timex_datalink_client_spec.rb
+++ b/spec/lib/timex_datalink_client_spec.rb
@@ -5,7 +5,7 @@ require "tzinfo"
 require "spec_helper"
 
 describe TimexDatalinkClient do
-  let(:serial_device) { "/dev/ttyACM0" }
+  let(:serial_device) { "/some/serial/device" }
   let(:verbose) { false }
 
   let(:models) do


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/1!

This PR adds support for verbose output!  To enable, pass `verbose: true` to `TimexDatalinkClient.new` like so:

```ruby
timex_datalink_client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models,  # model array goes here
  verbose: true
)
```

When `#write` is called on the `TimexDatalinkClient` instance, an output like this is written to the console:

```
55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA 
07 20 00 00 03 01 FE 
11 32 01 2B 00 35 09 07 16 19 0D 1D 02 01 02 B6 C0 
11 32 02 2B 07 35 09 07 16 1E 1D 0C 02 02 02 B9 1A 
12 50 01 09 00 00 00 20 0A 14 0E 24 1E 19 24 01 20 F0 
12 50 02 09 05 00 00 0F 18 1B 24 1B 0E 0A 15 01 91 AB 
12 50 03 09 05 00 00 10 0E 1D 24 1E 19 24 24 01 6B 7C 
12 50 04 09 05 00 00 18 1B 24 17 18 1D 24 24 01 AF F9 
12 50 05 09 05 00 00 1D 18 15 0D 24 22 18 1E 00 AF EB 
05 93 01 31 BD 
14 90 01 05 02 36 02 6F 02 8C 02 AB 03 02 02 02 16 02 59 09 
26 91 01 01 13 0A 1F 4C 1C A3 6C 0E D9 45 0E 79 39 12 14 2D D8 C6 FD 13 0B 18 44 8F E3 34 64 17 39 E4 E5 48 87 F4 
26 91 01 02 50 B4 60 1B F7 03 13 0C 19 38 5C 86 49 15 D9 45 0E 79 39 12 14 2D D8 C6 FD 0F 02 96 F7 3C 95 B3 93 6B 
26 91 01 03 91 8B A3 6C D2 05 71 3F 0E 04 91 A3 34 95 04 45 1D F9 54 9E D4 FC 10 11 21 22 33 33 CF 96 B2 75 95 DD 
26 91 01 04 22 69 31 4F 25 FE 0F 44 54 55 66 66 AF 0D C6 90 CB 86 81 D7 0F 1A 07 03 9B 53 39 0A E7 90 D8 43 CB 0E 
24 91 01 05 2E 0A 43 91 1D 46 76 91 43 3E 5E E7 6D CE 0F 0F 04 06 9B 53 39 0A E7 90 D8 43 0A 00 10 FC 20 5D 
05 92 01 A1 BC 
06 71 01 01 C3 90 
04 21 D8 C2 
```