### PR TITLE
Use boolean values for Alarm's audible attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,35 +157,35 @@ TimexDatalinkClient::Time.new(
 ```ruby
 TimexDatalinkClient::Alarm.new(
   number: 1,
-  audible: 1,
+  audible: true,
   time: Time.new(2022, 1, 1, 9, 0),
   message: "wake up"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 2,
-  audible: 1,
+  audible: true,
   time: Time.new(2022, 1, 1, 9, 5),
   message: "for real"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 3,
-  audible: 1,
+  audible: true,
   time: Time.new(2022, 1, 1, 9, 10),
   message: "get up"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 4,
-  audible: 1,
+  audible: true,
   time: Time.new(2022, 1, 1, 9, 15),
   message: "or not"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 5,
-  audible: 0,
+  audible: false,
   time: Time.new(2022, 1, 1, 11, 30),
   message: "told you"
 )
@@ -295,31 +295,31 @@ models = [
 
   TimexDatalinkClient::Alarm.new(
     number: 1,
-    audible: 1,
+    audible: true,
     time: Time.new(2022, 1, 1, 9, 0),
     message: "wake up"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 2,
-    audible: 1,
+    audible: true,
     time: Time.new(2022, 1, 1, 9, 5),
     message: "for real"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 3,
-    audible: 1,
+    audible: true,
     time: Time.new(2022, 1, 1, 9, 10),
     message: "get up"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 4,
-    audible: 1,
+    audible: true,
     time: Time.new(2022, 1, 1, 9, 15),
     message: "or not"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 5,
-    audible: 0,
+    audible: false,
     time: Time.new(2022, 1, 1, 11, 30),
     message: "told you"
   ),

--- a/lib/timex_datalink_client/alarm.rb
+++ b/lib/timex_datalink_client/alarm.rb
@@ -31,7 +31,7 @@ class TimexDatalinkClient
           0,
           0,
           message_characters,
-          audible
+          audible_integer
         ].flatten
       ]
     end
@@ -42,6 +42,10 @@ class TimexDatalinkClient
       message_padded = message.ljust(MESSAGE_LENGTH)
 
       chars_for(message_padded)
+    end
+
+    def audible_integer
+      audible ? 1 : 0
     end
   end
 end

--- a/spec/lib/timex_datalink_client/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/alarm_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe TimexDatalinkClient::Alarm do
   let(:number) { 1 }
-  let(:audible) { 0 }
+  let(:audible) { false }
   let(:time) { Time.new(1994) }
   let(:message) { "alarm 1" }
 
@@ -32,8 +32,8 @@ describe TimexDatalinkClient::Alarm do
       ]
     end
 
-    context "when audible is 1" do
-      let(:audible) { 1 }
+    context "when audible is true" do
+      let(:audible) { true }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x01]


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/7!

This PR uses true/false values for `Audible`'s `audible` attribute.