### PR TITLE
Use hourly_chime for SoundOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ TimexDatalinkClient::WristApp.new(
   )
 
   TimexDatalinkClient::SoundOptions.new(
-    hourly_chimes: 1,
+    hourly_chime: 1,
     button_beep: 0
   )
 ```
@@ -336,7 +336,7 @@ models = [
     sound_data: File.open("DATALINK/SND/DEFHIGH.SPC").read
   ),
   TimexDatalinkClient::SoundOptions.new(
-    hourly_chimes: 1,
+    hourly_chime: 1,
     button_beep: 1
   ),
 

--- a/lib/timex_datalink_client/sound_options.rb
+++ b/lib/timex_datalink_client/sound_options.rb
@@ -8,16 +8,16 @@ class TimexDatalinkClient
 
     CPACKET_BEEPS = [0x71]
 
-    attr_accessor :hourly_chimes, :button_beep
+    attr_accessor :hourly_chime, :button_beep
 
-    def initialize(hourly_chimes:, button_beep:)
-      @hourly_chimes = hourly_chimes
+    def initialize(hourly_chime:, button_beep:)
+      @hourly_chime = hourly_chime
       @button_beep = button_beep
     end
 
     def packets
       [
-        CPACKET_BEEPS + [hourly_chimes, button_beep]
+        CPACKET_BEEPS + [hourly_chime, button_beep]
       ]
     end
   end

--- a/spec/lib/timex_datalink_client/sound_options_spec.rb
+++ b/spec/lib/timex_datalink_client/sound_options_spec.rb
@@ -3,12 +3,12 @@
 require "spec_helper"
 
 describe TimexDatalinkClient::SoundOptions do
-  let(:hourly_chimes) { 0 }
+  let(:hourly_chime) { 0 }
   let(:button_beep) { 0 }
 
   let(:sound_options) do
     described_class.new(
-      hourly_chimes: hourly_chimes,
+      hourly_chime: hourly_chime,
       button_beep: button_beep
     )
   end
@@ -18,8 +18,8 @@ describe TimexDatalinkClient::SoundOptions do
 
     it_behaves_like "CRC-wrapped packets", [[0x71, 0x00, 0x00]]
 
-    context "when hourly chimes are enabled" do
-      let(:hourly_chimes) { 1 }
+    context "when hourly chime is enabled" do
+      let(:hourly_chime) { 1 }
 
       it_behaves_like "CRC-wrapped packets", [[0x71, 0x01, 0x00]]
     end
@@ -30,8 +30,8 @@ describe TimexDatalinkClient::SoundOptions do
       it_behaves_like "CRC-wrapped packets", [[0x71, 0x00, 0x01]]
     end
 
-    context "when hourly chimes and button beep are enabled" do
-      let(:hourly_chimes) { 1 }
+    context "when hourly chime and button beep are enabled" do
+      let(:hourly_chime) { 1 }
       let(:button_beep) { 1 }
 
       it_behaves_like "CRC-wrapped packets", [[0x71, 0x01, 0x01]]


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/11!

This PR replaces `hourly_chimes` with `hourly_chime` in `SoundOptions`.  This is more consistent with the Timex Datalink software:

![image](https://user-images.githubusercontent.com/820984/188840097-5babce2a-fcff-4857-9412-1d20b3398ac0.png)