### PR TITLE
Use boolean params in sound options

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ TimexDatalinkClient::WristApp.new(
   )
 
   TimexDatalinkClient::SoundOptions.new(
-    hourly_chime: 1,
-    button_beep: 0
+    hourly_chime: true,
+    button_beep: false
   )
 ```
 
@@ -336,8 +336,8 @@ models = [
     sound_data: File.open("DATALINK/SND/DEFHIGH.SPC").read
   ),
   TimexDatalinkClient::SoundOptions.new(
-    hourly_chime: 1,
-    button_beep: 1
+    hourly_chime: true,
+    button_beep: true
   ),
 
   TimexDatalinkClient::WristApp.new(

--- a/lib/timex_datalink_client/sound_options.rb
+++ b/lib/timex_datalink_client/sound_options.rb
@@ -17,8 +17,16 @@ class TimexDatalinkClient
 
     def packets
       [
-        CPACKET_BEEPS + [hourly_chime, button_beep]
+        CPACKET_BEEPS + [hourly_chime_integer, button_beep_integer]
       ]
+    end
+
+    def hourly_chime_integer
+      hourly_chime ? 1 : 0
+    end
+
+    def button_beep_integer
+      button_beep ? 1 : 0
     end
   end
 end

--- a/spec/lib/timex_datalink_client/sound_options_spec.rb
+++ b/spec/lib/timex_datalink_client/sound_options_spec.rb
@@ -3,8 +3,8 @@
 require "spec_helper"
 
 describe TimexDatalinkClient::SoundOptions do
-  let(:hourly_chime) { 0 }
-  let(:button_beep) { 0 }
+  let(:hourly_chime) { false }
+  let(:button_beep) { false }
 
   let(:sound_options) do
     described_class.new(
@@ -19,20 +19,20 @@ describe TimexDatalinkClient::SoundOptions do
     it_behaves_like "CRC-wrapped packets", [[0x71, 0x00, 0x00]]
 
     context "when hourly chime is enabled" do
-      let(:hourly_chime) { 1 }
+      let(:hourly_chime) { true }
 
       it_behaves_like "CRC-wrapped packets", [[0x71, 0x01, 0x00]]
     end
 
     context "when button beep is enabled" do
-      let(:button_beep) { 1 }
+      let(:button_beep) { true }
 
       it_behaves_like "CRC-wrapped packets", [[0x71, 0x00, 0x01]]
     end
 
     context "when hourly chime and button beep are enabled" do
-      let(:hourly_chime) { 1 }
-      let(:button_beep) { 1 }
+      let(:hourly_chime) { true }
+      let(:button_beep) { true }
 
       it_behaves_like "CRC-wrapped packets", [[0x71, 0x01, 0x01]]
     end


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/5!

This PR makes `SoundOptions` use boolean values, like so:

```ruby
  TimexDatalinkClient::SoundOptions.new(
    hourly_chime: true,
    button_beep: false
  )
```