### PR TITLE
Add byte_sleep and packet_sleep options

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -17,11 +17,13 @@ require "timex_datalink_client/version"
 require "timex_datalink_client/wrist_app"
 
 class TimexDatalinkClient
-  attr_accessor :serial_device, :models, :verbose
+  attr_accessor :serial_device, :models, :byte_sleep, :packet_sleep, :verbose
 
-  def initialize(serial_device:, models: [], verbose: false)
+  def initialize(serial_device:, models: [], byte_sleep: nil, packet_sleep: nil, verbose: false)
     @serial_device = serial_device
     @models = models
+    @byte_sleep = byte_sleep
+    @packet_sleep = packet_sleep
     @verbose = verbose
   end
 
@@ -38,6 +40,8 @@ class TimexDatalinkClient
   def notebook_adapter
     @notebook_adapter ||= NotebookAdapter.new(
       serial_device: serial_device,
+      byte_sleep: byte_sleep,
+      packet_sleep: packet_sleep,
       verbose: verbose
     )
   end

--- a/lib/timex_datalink_client/notebook_adapter.rb
+++ b/lib/timex_datalink_client/notebook_adapter.rb
@@ -4,13 +4,15 @@ require "rubyserial"
 
 class TimexDatalinkClient
   class NotebookAdapter
-    BYTE_SLEEP = 0.025
-    PACKET_SLEEP = 0.25
+    BYTE_SLEEP_DEFAULT = 0.025
+    PACKET_SLEEP_DEFAULT = 0.25
 
-    attr_accessor :serial_device, :verbose
+    attr_accessor :serial_device, :byte_sleep, :packet_sleep, :verbose
 
-    def initialize(serial_device:, verbose: false)
+    def initialize(serial_device:, byte_sleep: nil, packet_sleep: nil, verbose: false)
       @serial_device = serial_device
+      @byte_sleep = byte_sleep || BYTE_SLEEP_DEFAULT
+      @packet_sleep = packet_sleep || PACKET_SLEEP_DEFAULT
       @verbose = verbose
     end
 
@@ -21,10 +23,10 @@ class TimexDatalinkClient
 
           serial.write(byte.chr)
 
-          sleep(BYTE_SLEEP)
+          sleep(byte_sleep)
         end
 
-        sleep(PACKET_SLEEP)
+        sleep(packet_sleep)
 
         puts if verbose
       end

--- a/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
+++ b/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
@@ -4,11 +4,15 @@ require "spec_helper"
 
 describe TimexDatalinkClient::NotebookAdapter do
   let(:serial_device) { "/some/serial/device" }
+  let(:byte_sleep) { 0.006 }
+  let(:packet_sleep) { 0.06 }
   let(:verbose) { false }
 
   subject(:notebook_adapter) do
     described_class.new(
       serial_device: serial_device,
+      byte_sleep: byte_sleep,
+      packet_sleep: packet_sleep,
       verbose: verbose
     )
   end
@@ -29,10 +33,10 @@ describe TimexDatalinkClient::NotebookAdapter do
       packets.each do |packet|
         packet.each do |byte|
           expect(serial_double).to receive(:write).with(byte.chr).ordered
-          expect(notebook_adapter).to receive(:sleep).with(0.025).ordered
+          expect(notebook_adapter).to receive(:sleep).with(byte_sleep).ordered
         end
 
-        expect(notebook_adapter).to receive(:sleep).with(0.25).ordered
+        expect(notebook_adapter).to receive(:sleep).with(packet_sleep).ordered
       end
 
       notebook_adapter.write(packets)
@@ -52,17 +56,17 @@ describe TimexDatalinkClient::NotebookAdapter do
     context "when verbose is true" do
       let(:verbose) { true }
 
-      it "writes serial data with correct sleep lengths and console output" do
+      it "writes serial data with console output" do
         expect(Serial).to receive(:new).with(serial_device).and_return(serial_double)
 
         packets.each do |packet|
           packet.each do |byte|
             expect(notebook_adapter).to receive(:printf).with("%.2X ", byte).ordered
-            expect(serial_double).to receive(:write).with(byte.chr).ordered
-            expect(notebook_adapter).to receive(:sleep).with(0.025).ordered
+            expect(serial_double).to receive(:write).ordered
+            expect(notebook_adapter).to receive(:sleep).ordered
           end
 
-          expect(notebook_adapter).to receive(:sleep).with(0.25).ordered
+          expect(notebook_adapter).to receive(:sleep).ordered
           expect(notebook_adapter).to receive(:puts).ordered
         end
 

--- a/spec/lib/timex_datalink_client_spec.rb
+++ b/spec/lib/timex_datalink_client_spec.rb
@@ -6,6 +6,8 @@ require "spec_helper"
 
 describe TimexDatalinkClient do
   let(:serial_device) { "/some/serial/device" }
+  let(:byte_sleep) { 0.006 }
+  let(:packet_sleep) { 0.06 }
   let(:verbose) { false }
 
   let(:models) do
@@ -35,6 +37,8 @@ describe TimexDatalinkClient do
     described_class.new(
       serial_device: serial_device,
       models: models,
+      byte_sleep: byte_sleep,
+      packet_sleep: packet_sleep,
       verbose: verbose
     )
   end
@@ -80,6 +84,8 @@ describe TimexDatalinkClient do
 
       expect(TimexDatalinkClient::NotebookAdapter).to receive(:new).with(
         serial_device: serial_device,
+        byte_sleep: byte_sleep,
+        packet_sleep: packet_sleep,
         verbose: verbose
       ).and_return(notebook_adapter_double)
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/15!

This PR introduces user-tunable options to tweak the byte sleep and packet sleep options.  It is used like this:

```ruby
client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models,
  byte_sleep: 0.006,
  packet_sleep: 0.06,
  verbose: true
)
```

For what it's worth, the values above are the fastest values I can achieve without any intermittent errors with my Notebook Adapter clone: https://github.com/synthead/timex-datalink-arduino