### PR TITLE
Remove pull_request event trigger from CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,7 @@
 name: Timex Datalink Client CI
 
-on: [push, pull_request]
+on: push
+
 jobs:
   rspec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/19!

This PR removes the pull_request event from CI.  It's making the CI twice without benefit:

![image](https://user-images.githubusercontent.com/820984/189055375-d6b913ba-9cfa-40e7-9b99-2c0063aa9eba.png)
