### PR TITLE
Add nil and use ::Time types in YARDoc documentation

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -24,8 +24,8 @@ class TimexDatalinkClient
   # @param serial_device [String] Path to serial device.
   # @param models [Array<Alarm, Eeprom, End, SoundOptions, SoundTheme, Start, Sync, Time, WristApp>] Models to compile
   #   data for.
-  # @param byte_sleep [Integer] Time to sleep after sending byte.
-  # @param packet_sleep [Integer] Time to sleep after sending packet of bytes.
+  # @param byte_sleep [Integer, nil] Time to sleep after sending byte.
+  # @param packet_sleep [Integer, nil] Time to sleep after sending packet of bytes.
   # @param verbose [Boolean] Write verbose output to console.
   # @return [TimexDatalinkClient] TimexDatalinkClient instance.
   def initialize(serial_device:, models: [], byte_sleep: nil, packet_sleep: nil, verbose: false)

--- a/lib/timex_datalink_client/alarm.rb
+++ b/lib/timex_datalink_client/alarm.rb
@@ -18,7 +18,7 @@ class TimexDatalinkClient
     #
     # @param number [Integer] Alarm number (from 1 to 5).
     # @param audible [Boolean] Toggle alarm sounds.
-    # @param time [Time] Time of alarm.
+    # @param time [::Time] Time of alarm.
     # @param message [String] Alarm message text.
     # @return [Alarm] Alarm instance.
     def initialize(number:, audible:, time:, message:)

--- a/lib/timex_datalink_client/eeprom/anniversary.rb
+++ b/lib/timex_datalink_client/eeprom/anniversary.rb
@@ -13,7 +13,7 @@ class TimexDatalinkClient
 
       # Create an Anniversary instance.
       #
-      # @param time [Time] Time of anniversary.
+      # @param time [::Time] Time of anniversary.
       # @param anniversary [String] Anniversary text.
       # @return [Anniversary] Anniversary instance.
       def initialize(time:, anniversary:)

--- a/lib/timex_datalink_client/eeprom/appointment.rb
+++ b/lib/timex_datalink_client/eeprom/appointment.rb
@@ -13,7 +13,7 @@ class TimexDatalinkClient
 
       # Create an Appointment instance.
       #
-      # @param time [Time] Time of appointment.
+      # @param time [::Time] Time of appointment.
       # @param message [String] Appointment text.
       # @return [Appointment] Appointment instance.
       def initialize(time:, message:)

--- a/lib/timex_datalink_client/time.rb
+++ b/lib/timex_datalink_client/time.rb
@@ -17,7 +17,7 @@ class TimexDatalinkClient
     # @param zone [Integer] Time zone number (1 or 2).
     # @param is_24h [Boolean] Toggle 24 hour time.
     # @param date_format [Integer] Date format.
-    # @param time [Time] Time to set (including time zone).
+    # @param time [::Time] Time to set (including time zone).
     # @return [Time] Time instance.
     def initialize(zone:, is_24h:, date_format:, time:)
       @zone = zone


### PR DESCRIPTION
Follow-up to https://github.com/synthead/timex_datalink_client/issues/6.

Fixes a couple YARDoc bugs:

- Add `nil` type to some `TimexDatalinkClient#initialize` params
- Use `::Time` in some model params (so YARDoc doesn't link to `TimexDatalinkClient::Time`)