### PR TITLE
Allow user submitted time zone names

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ TimexDatalinkClient::Time.new(
   time: Time.new(2022, 9, 5, 11, 39, 44),
   is_24h: true,
   date_format: 0,
-),
+)
 ```
 
 ### Alarms

--- a/README.md
+++ b/README.md
@@ -129,22 +129,18 @@ TimexDatalinkClient::Eeprom.new(lists: lists)
 <image src="https://user-images.githubusercontent.com/820984/188431136-e2a40eec-d9cd-4b15-992e-3d7b1251b0ee.png" width="600px">
 
 ```ruby
-timezone_1 = TZInfo::Timezone.get("US/Pacific")
-time_1 = timezone_1.local_time(2022, 9, 5, 3, 39, 44)
-
 TimexDatalinkClient::Time.new(
   zone: 1,
-  time: time_1,
+  name: "pdt",
+  time: Time.new(2022, 9, 5, 3, 39, 44),
   is_24h: false,
   date_format: 0,
 )
 
-timezone_2 = TZInfo::Timezone.get("GMT")
-time_2 = timezone_2.local_time(2022, 9, 5, 11, 39, 44)
-
 TimexDatalinkClient::Time.new(
   zone: 2,
-  time: time_2,
+  name: "gmt",
+  time: Time.new(2022, 9, 5, 11, 39, 44),
   is_24h: true,
   date_format: 0,
 ),

--- a/lib/timex_datalink_client/time.rb
+++ b/lib/timex_datalink_client/time.rb
@@ -18,12 +18,14 @@ class TimexDatalinkClient
     # @param is_24h [Boolean] Toggle 24 hour time.
     # @param date_format [Integer] Date format.
     # @param time [::Time] Time to set (including time zone).
+    # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max)
     # @return [Time] Time instance.
-    def initialize(zone:, is_24h:, date_format:, time:)
+    def initialize(zone:, is_24h:, date_format:, time:, name: nil)
       @zone = zone
       @is_24h = is_24h
       @date_format = date_format
       @time = time
+      @name = name
     end
 
     # Compile packets for a time.
@@ -40,7 +42,7 @@ class TimexDatalinkClient
           time.month,
           time.day,
           year_mod_1900,
-          timezone_characters,
+          name_characters,
           wday_from_monday,
           is_24h_value,
           date_format
@@ -50,8 +52,12 @@ class TimexDatalinkClient
 
     private
 
-    def timezone_characters
-      chars_for(time.zone.downcase, length: 3, pad: true)
+    def name
+      @name || time.zone.downcase
+    end
+
+    def name_characters
+      chars_for(name, length: 3, pad: true)
     end
 
     def year_mod_1900

--- a/spec/lib/timex_datalink_client/time_spec.rb
+++ b/spec/lib/timex_datalink_client/time_spec.rb
@@ -10,13 +10,15 @@ describe TimexDatalinkClient::Time do
   let(:date_format) { 0 }
   let(:tzinfo) { TZInfo::Timezone.get("US/Pacific") }
   let(:time) { tzinfo.local_time(2015, 10, 21, 19, 28, 32) }
+  let(:name) { nil }
 
   let(:time_instance) do
     described_class.new(
       zone: zone,
       is_24h: is_24h,
       date_format: date_format,
-      time: time
+      time: time,
+      name: name
     )
   end
 
@@ -57,6 +59,22 @@ describe TimexDatalinkClient::Time do
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x37, 0x13, 0x24, 0x09, 0x13, 0x61, 0x17, 0x23, 0x1c, 0x04, 0x01, 0x00]
+      ]
+    end
+
+    context "when name is \"1\"" do
+      let(:name) { "1" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x01, 0x24, 0x24, 0x02, 0x01, 0x00]
+      ]
+    end
+
+    context "when name is \"longer than 3 characters\"" do
+      let(:name) { "longer than 3 characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x15, 0x18, 0x17, 0x02, 0x01, 0x00]
       ]
     end
   end


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/27!

This PR adds user-issued time zone names, like so:

```ruby
TimexDatalinkClient::Time.new(
  zone: 1,
  name: "pdt",
  time: Time.new(2022, 9, 5, 3, 39, 44),
  is_24h: false,
  date_format: 0,
)

TimexDatalinkClient::Time.new(
  zone: 2,
  name: "gmt",
  time: Time.new(2022, 9, 5, 11, 39, 44),
  is_24h: true,
  date_format: 0,
)
```

Time zone names are still implied if a `name` attribute is not set.  This looks like this:

```ruby
time1 = Time.now + 4
time2 = time1.dup.utc

# name will be the time zone of time1, i.e. "cdt" if in US central daylight time
TimexDatalinkClient::Time.new(
  zone: 1,
  is_24h: false,
  date_format: 2,
  time: time1
)

# name will be "utc"
TimexDatalinkClient::Time.new(
  zone: 2,
  is_24h: true,
  date_format: 2,
  time: time2
)
```