### PR TITLE
Make strings in all models case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ Here are some examples of data in the original Timex Datalink software and how t
 appointments = [
   TimexDatalinkClient::Eeprom::Appointment.new(
     time: Time.new(2022, 10, 31, 19, 0),
-    message: "scare the neighbors"
+    message: "Scare the neighbors"
   ),
   TimexDatalinkClient::Eeprom::Appointment.new(
     time: Time.new(2022, 11, 24, 17, 0),
-    message: "feed the neighbors"
+    message: "Feed the neighbors"
   ),
   TimexDatalinkClient::Eeprom::Appointment.new(
     time: Time.new(2022, 12, 25, 14, 0),
-    message: "spoil the neighbors"
+    message: "Spoil the neighbors"
   )
 ]
 
@@ -73,11 +73,11 @@ TimexDatalinkClient::Eeprom.new(
 anniversaries = [
   TimexDatalinkClient::Eeprom::Anniversary.new(
     time: Time.new(1985, 7, 3),
-    anniversary: "release of back to the future"
+    anniversary: "Release of Back to the Future"
   ),
   TimexDatalinkClient::Eeprom::Anniversary.new(
     time: Time.new(1968, 4, 6),
-    anniversary: "release of 2001"
+    anniversary: "Release of 2001"
   )
 ]
 
@@ -91,14 +91,14 @@ TimexDatalinkClient::Eeprom.new(anniversaries: anniversaries)
 ```ruby
 phone_numbers = [
   TimexDatalinkClient::Eeprom::PhoneNumber.new(
-    name: "marty mcfly",
+    name: "Marty McFly",
     number: "1112223333",
-    type: "h"
+    type: "H"
   ),
   TimexDatalinkClient::Eeprom::PhoneNumber.new(
-    name: "doc brown",
+    name: "Doc Brown",
     number: "4445556666",
-    type: "c"
+    type: "C"
   )
 ]
 
@@ -112,11 +112,11 @@ TimexDatalinkClient::Eeprom.new(phone_numbers: phone_numbers)
 ```ruby
 lists = [
   TimexDatalinkClient::Eeprom::List.new(
-    list_entry: "muffler bearings",
+    list_entry: "Muffler bearings",
     priority: 2
   ),
   TimexDatalinkClient::Eeprom::List.new(
-    list_entry: "headlight fluid",
+    list_entry: "Headlight fluid",
     priority: 4
   )
 ]
@@ -131,7 +131,7 @@ TimexDatalinkClient::Eeprom.new(lists: lists)
 ```ruby
 TimexDatalinkClient::Time.new(
   zone: 1,
-  name: "pdt",
+  name: "PDT",
   time: Time.new(2022, 9, 5, 3, 39, 44),
   is_24h: false,
   date_format: 0,
@@ -139,7 +139,7 @@ TimexDatalinkClient::Time.new(
 
 TimexDatalinkClient::Time.new(
   zone: 2,
-  name: "gmt",
+  name: "GMT",
   time: Time.new(2022, 9, 5, 11, 39, 44),
   is_24h: true,
   date_format: 0,
@@ -155,35 +155,35 @@ TimexDatalinkClient::Alarm.new(
   number: 1,
   audible: true,
   time: Time.new(2022, 1, 1, 9, 0),
-  message: "wake up"
+  message: "Wake up"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 2,
   audible: true,
   time: Time.new(2022, 1, 1, 9, 5),
-  message: "for real"
+  message: "For real"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 3,
   audible: true,
   time: Time.new(2022, 1, 1, 9, 10),
-  message: "get up"
+  message: "Get up"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 4,
   audible: true,
   time: Time.new(2022, 1, 1, 9, 15),
-  message: "or not"
+  message: "Or not"
 )
 
 TimexDatalinkClient::Alarm.new(
   number: 5,
   audible: false,
   time: Time.new(2022, 1, 1, 11, 30),
-  message: "told you"
+  message: "Told you"
 )
 ```
 
@@ -218,49 +218,49 @@ require "timex_datalink_client"
 appointments = [
   TimexDatalinkClient::Eeprom::Appointment.new(
     time: Time.new(2022, 10, 31, 19, 0),
-    message: "scare the neighbors"
+    message: "Scare the neighbors"
   ),
   TimexDatalinkClient::Eeprom::Appointment.new(
     time: Time.new(2022, 11, 24, 17, 0),
-    message: "feed the neighbors"
+    message: "Feed the neighbors"
   ),
   TimexDatalinkClient::Eeprom::Appointment.new(
     time: Time.new(2022, 12, 25, 14, 0),
-    message: "spoil the neighbors"
+    message: "Spoil the neighbors"
   )
 ]
 
 anniversaries = [
   TimexDatalinkClient::Eeprom::Anniversary.new(
     time: Time.new(1985, 7, 3),
-    anniversary: "release of back to the future"
+    anniversary: "Release of Back to the Future"
   ),
   TimexDatalinkClient::Eeprom::Anniversary.new(
     time: Time.new(1968, 4, 6),
-    anniversary: "release of 2001"
+    anniversary: "Release of 2001"
   )
 ]
 
 phone_numbers = [
   TimexDatalinkClient::Eeprom::PhoneNumber.new(
-    name: "marty mcfly",
+    name: "Marty McFly",
     number: "1112223333",
-    type: "h"
+    type: "H"
   ),
   TimexDatalinkClient::Eeprom::PhoneNumber.new(
-    name: "doc brown",
+    name: "Doc Brown",
     number: "4445556666",
-    type: "c"
+    type: "C"
   )
 ]
 
 lists = [
   TimexDatalinkClient::Eeprom::List.new(
-    list_entry: "muffler bearings",
+    list_entry: "Muffler bearings",
     priority: 2
   ),
   TimexDatalinkClient::Eeprom::List.new(
-    list_entry: "headlight fluid",
+    list_entry: "Headlight fluid",
     priority: 4
   )
 ]
@@ -289,31 +289,31 @@ models = [
     number: 1,
     audible: true,
     time: Time.new(2022, 1, 1, 9, 0),
-    message: "wake up"
+    message: "Wake up"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 2,
     audible: true,
     time: Time.new(2022, 1, 1, 9, 5),
-    message: "for real"
+    message: "For real"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 3,
     audible: true,
     time: Time.new(2022, 1, 1, 9, 10),
-    message: "get up"
+    message: "Get up"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 4,
     audible: true,
     time: Time.new(2022, 1, 1, 9, 15),
-    message: "or not"
+    message: "Or not"
   ),
   TimexDatalinkClient::Alarm.new(
     number: 5,
     audible: false,
     time: Time.new(2022, 1, 1, 11, 30),
-    message: "told you"
+    message: "Told you"
   ),
 
   TimexDatalinkClient::Eeprom.new(

--- a/lib/timex_datalink_client/helpers/char_encoders.rb
+++ b/lib/timex_datalink_client/helpers/char_encoders.rb
@@ -10,7 +10,7 @@ class TimexDatalinkClient
       PHONE_CHARS = "0123456789cfhpw "
 
       def chars_for(string_chars, char_map: CHARS, length: nil, pad: false)
-        formatted_chars = string_chars[0..length.to_i - 1]
+        formatted_chars = string_chars.downcase[0..length.to_i - 1]
         formatted_chars = formatted_chars.ljust(length) if pad
 
         formatted_chars.each_char.map do |char|

--- a/spec/lib/timex_datalink_client/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/alarm_spec.rb
@@ -6,7 +6,7 @@ describe TimexDatalinkClient::Alarm do
   let(:number) { 1 }
   let(:audible) { false }
   let(:time) { Time.new(1994) }
-  let(:message) { "alarm 1" }
+  let(:message) { "Alarm 1" }
 
   let(:alarm) do
     described_class.new(
@@ -48,8 +48,8 @@ describe TimexDatalinkClient::Alarm do
       ]
     end
 
-    context "when message is \"wake up with more than 8 characters\"" do
-      let(:message) { "wake up with more than 8 characters" }
+    context "when message is \"Wake Up with More than 8 Characters\"" do
+      let(:message) { "Wake Up with More than 8 Characters" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x20, 0x0a, 0x14, 0x0e, 0x24, 0x1e, 0x19, 0x24, 0x00]

--- a/spec/lib/timex_datalink_client/eeprom/anniversary_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/anniversary_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe TimexDatalinkClient::Eeprom::Anniversary do
   let(:time) { Time.new(1997, 9, 19) }
-  let(:anniversary) { "timexdl.exe modified date" }
+  let(:anniversary) { "TIMEXDL.EXE modified date" }
 
   let(:anniversary_instance) do
     described_class.new(
@@ -30,8 +30,8 @@ describe TimexDatalinkClient::Eeprom::Anniversary do
       ]
     end
 
-    context "when anniversary is \"to the delorean with more than 31 characters\"" do
-      let(:anniversary) { "to the delorean with more than 31 characters" }
+    context "when anniversary is \"To the Delorean with More Than 31 Characters\"" do
+      let(:anniversary) { "To the Delorean with More Than 31 Characters" }
 
       it_behaves_like "a length-prefixed packet", [
         0x09, 0x13, 0x1d, 0x46, 0x76, 0x91, 0x43, 0x36, 0x4e, 0x85, 0x6d, 0x8e, 0x72, 0x91, 0xa0, 0xd4, 0x45, 0xa4,

--- a/spec/lib/timex_datalink_client/eeprom/appointment_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/appointment_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe TimexDatalinkClient::Eeprom::Appointment do
   let(:time) { Time.new(1997, 9, 19) }
-  let(:message) { "release timexdl.exe" }
+  let(:message) { "Release TIMEXDL.EXE" }
 
   let(:appointment) do
     described_class.new(
@@ -28,8 +28,8 @@ describe TimexDatalinkClient::Eeprom::Appointment do
       ]
     end
 
-    context "when anniversary is \"to the delorean with more than 31 characters\"" do
-      let(:message) { "to the delorean with more than 31 characters" }
+    context "when message is \"To the Delorean with More Than 31 Characters\"" do
+      let(:message) { "To the Delorean with More Than 31 Characters" }
 
       it_behaves_like "a length-prefixed packet", [
         0x09, 0x13, 0x00, 0x1d, 0x46, 0x76, 0x91, 0x43, 0x36, 0x4e, 0x85, 0x6d, 0x8e, 0x72, 0x91, 0xa0, 0xd4, 0x45,

--- a/spec/lib/timex_datalink_client/eeprom/list_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/list_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe TimexDatalinkClient::Eeprom::List do
-  let(:list_entry) { "muffler bearings" }
+  let(:list_entry) { "Muffler Bearings" }
   let(:priority) { 0 }
 
   let(:list) do
@@ -28,8 +28,8 @@ describe TimexDatalinkClient::Eeprom::List do
       ]
     end
 
-    context "when list_entry is \"headlight fluid with more than 31 characters\"" do
-      let(:list_entry) { "headlight fluid with more than 31 characters" }
+    context "when list_entry is \"Headlight Fluid with More than 31 Characters\"" do
+      let(:list_entry) { "Headlight Fluid with More than 31 Characters" }
 
       it_behaves_like "a length-prefixed packet", [
         0x00, 0x91, 0xa3, 0x34, 0x95, 0x04, 0x45, 0x1d, 0xf9, 0x54, 0x9e, 0xd4, 0x90, 0xa0, 0xd4, 0x45, 0xa4, 0x85,

--- a/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe TimexDatalinkClient::Eeprom::PhoneNumber do
-  let(:name) { "marty mcfly" }
+  let(:name) { "Marty McFly" }
   let(:number) { "1234567890" }
   let(:type) { "c" }
 
@@ -22,8 +22,8 @@ describe TimexDatalinkClient::Eeprom::PhoneNumber do
       0x21, 0x43, 0x65, 0x87, 0x09, 0xaf, 0x96, 0xb2, 0x75, 0x22, 0x69, 0x31, 0x4f, 0x25, 0xfe
     ]
 
-    context "when name is \"doc brown with more than 31 characters\"" do
-      let(:name) { "doc brown with more than 31 characters" }
+    context "when name is \"Doc Brown with More than 31 Characters\"" do
+      let(:name) { "Doc Brown with More than 31 Characters" }
 
       it_behaves_like "a length-prefixed packet", [
         0x21, 0x43, 0x65, 0x87, 0x09, 0xaf, 0x0d, 0xc6, 0x90, 0xcb, 0x86, 0x81, 0x17, 0x09, 0x4a, 0x5d, 0x44, 0x5a,
@@ -55,7 +55,7 @@ describe TimexDatalinkClient::Eeprom::PhoneNumber do
       ]
     end
 
-    context "when type is \"h\"" do
+    context "when type is \"H\"" do
       let(:type) { "h" }
 
       it_behaves_like "a length-prefixed packet", [

--- a/spec/lib/timex_datalink_client/time_spec.rb
+++ b/spec/lib/timex_datalink_client/time_spec.rb
@@ -78,8 +78,8 @@ describe TimexDatalinkClient::Time do
       ]
     end
 
-    context "when name is \"longer than 3 characters\"" do
-      let(:name) { "longer than 3 characters" }
+    context "when name is \"Longer than 3 Characters\"" do
+      let(:name) { "Longer than 3 Characters" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x15, 0x18, 0x17, 0x02, 0x01, 0x00]


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/30!

This PR makes all strings case-insensitive when mapping to bytes on the watch.  This means that "test", "Test", and "TEST" will all map to the same characters.

The Datalink 150 only presents the characters as uppercase, and has no ability to store characters with case, so this allows the models to accept more flexible data that would be expected in natural language.