### PR TITLE
Use homepage URL with version tag

### DIFF
--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/version.rb",
     "lib/timex_datalink_client/wrist_app.rb"
   ]
-  s.homepage    = "https://github.com/synthead/timex_datalink_client"
+
+  s.homepage    = "https://github.com/synthead/timex_datalink_client/tree/v#{s.version}"
   s.license     = "MIT"
 
   s.add_dependency "crc", "~> 0.4.2"


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/34!

This PR makes the homepage on rubygems.org link to a currently-shipped version.  The homepage is found on [the gem page](https://rubygems.org/gems/timex_datalink_client) here:

![image](https://user-images.githubusercontent.com/820984/189463700-b4821531-d956-4364-b676-d54c6c4aecf2.png)

As of this writing, the tagged URL with the current version at 0.4.0 is:

https://github.com/synthead/timex_datalink_client/tree/v0.4.0