### PR TITLE
Remove description from gemspec

### DIFF
--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -8,6 +8,9 @@ Gem::Specification.new do |s|
   s.summary     = "Library for optical Timex Datalink watches"
   s.authors     = ["Maxwell Pray"]
   s.email       = "synthead@gmail.com"
+  s.homepage    = "https://github.com/synthead/timex_datalink_client/tree/v#{s.version}"
+  s.license     = "MIT"
+
   s.files       = [
     "lib/timex_datalink_client.rb",
     "lib/timex_datalink_client/alarm.rb",
@@ -30,9 +33,6 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/version.rb",
     "lib/timex_datalink_client/wrist_app.rb"
   ]
-
-  s.homepage    = "https://github.com/synthead/timex_datalink_client/tree/v#{s.version}"
-  s.license     = "MIT"
 
   s.add_dependency "crc", "~> 0.4.2"
   s.add_dependency "rubyserial", "~> 0.6.0"

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.name        = "timex_datalink_client"
   s.version     = TimexDatalinkClient::VERSION
   s.summary     = "Library for optical Timex Datalink watches"
-  s.description = "Write data to Timex Datalink watches with an optical sensor"
   s.authors     = ["Maxwell Pray"]
   s.email       = "synthead@gmail.com"
   s.files       = [

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -5,7 +5,7 @@ require_relative "lib/timex_datalink_client/version.rb"
 Gem::Specification.new do |s|
   s.name        = "timex_datalink_client"
   s.version     = TimexDatalinkClient::VERSION
-  s.summary     = "Library for optical Timex Datalink watches"
+  s.summary     = "Write data to Timex Datalink devices with an optical sensor"
   s.authors     = ["Maxwell Pray"]
   s.email       = "synthead@gmail.com"
   s.homepage    = "https://github.com/synthead/timex_datalink_client/tree/v#{s.version}"


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/36 :+1: 

Includes these changes to `timex_datalink_client.gemspec`:

- Some reordering of lines
- Removed description
- Updated summary to be a little more descriptive