### PR TITLE
Add Sync, Start, and Stop models for protocol 1

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -3,6 +3,10 @@
 require "timex_datalink_client/version"
 require "timex_datalink_client/notebook_adapter"
 
+require "timex_datalink_client/protocol_1/end"
+require "timex_datalink_client/protocol_1/start"
+require "timex_datalink_client/protocol_1/sync"
+
 require "timex_datalink_client/protocol_3/alarm"
 require "timex_datalink_client/protocol_3/eeprom"
 require "timex_datalink_client/protocol_3/eeprom/anniversary"

--- a/lib/timex_datalink_client/protocol_1/end.rb
+++ b/lib/timex_datalink_client/protocol_1/end.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/end"
+
+class TimexDatalinkClient
+  class Protocol1
+    class End < End
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_1/start.rb
+++ b/lib/timex_datalink_client/protocol_1/start.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol1
+    class Start
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_START = [0x20, 0x00, 0x00, 0x01]
+
+      # Compile packets for data start command.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [CPACKET_START]
+      end
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_1/sync.rb
+++ b/lib/timex_datalink_client/protocol_1/sync.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/sync"
+
+class TimexDatalinkClient
+  class Protocol1
+    class Sync < Sync
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_1/end_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/end_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol1::End do
+  let(:end_instance) { described_class.new }
+
+  describe "#packets", :crc do
+    subject(:packets) { end_instance.packets }
+
+    it_behaves_like "CRC-wrapped packets", [[0x21]]
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_1/start_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/start_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol1::Start do
+  let(:start) { described_class.new }
+
+  describe "#packets", :crc do
+    subject(:packets) { start.packets }
+
+    it_behaves_like "CRC-wrapped packets", [[0x20, 0x00, 0x00, 0x01]]
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_1/sync_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/sync_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol1::Sync do
+  let(:length) { 200 }
+  let(:sync) { described_class.new(length: length) }
+
+  describe "#packets" do
+    subject(:packets) { sync.packets }
+
+    it { should eq([[0x55] * length + [0xaa] * 40]) }
+
+    context "when length is 350" do
+      let(:length) { 350 }
+
+      it { should eq([[0x55] * length + [0xaa] * 40]) }
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -23,6 +23,10 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/helpers/crc_packets_wrapper.rb",
     "lib/timex_datalink_client/helpers/length_packet_wrapper.rb",
 
+    "lib/timex_datalink_client/protocol_1/end.rb",
+    "lib/timex_datalink_client/protocol_1/start.rb",
+    "lib/timex_datalink_client/protocol_1/sync.rb",
+
     "lib/timex_datalink_client/protocol_3/alarm.rb",
     "lib/timex_datalink_client/protocol_3/eeprom.rb",
     "lib/timex_datalink_client/protocol_3/eeprom/anniversary.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/47!

This PR adds three models:

- `TimexDatalinkClient::Protocol1:Sync`
- `TimexDatalinkClient::Protocol1:Start`
- `TimexDatalinkClient::Protocol1:End`

Here's how to use them to transfer data to a Datalink 50 or Datalink 70:

```ruby
models = [
  TimexDatalinkClient::Protocol1::Sync.new(length: 50),
  TimexDatalinkClient::Protocol1::Start.new,
  # future models to transfer goes here
  TimexDatalinkClient::Protocol1::End.new
]

client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models
)

client.write
```