### PR TITLE
Add Time model for protocol 1

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -6,6 +6,7 @@ require "timex_datalink_client/notebook_adapter"
 require "timex_datalink_client/protocol_1/end"
 require "timex_datalink_client/protocol_1/start"
 require "timex_datalink_client/protocol_1/sync"
+require "timex_datalink_client/protocol_1/time"
 
 require "timex_datalink_client/protocol_3/alarm"
 require "timex_datalink_client/protocol_3/eeprom"

--- a/lib/timex_datalink_client/protocol_1/time.rb
+++ b/lib/timex_datalink_client/protocol_1/time.rb
@@ -15,7 +15,7 @@ class TimexDatalinkClient
       #
       # @param zone [Integer] Time zone number (1 or 2).
       # @param is_24h [Boolean] Toggle 24 hour time.
-      # @param time [::Time] Time to set (including time zone).
+      # @param time [::Time] Time to set.
       # @return [Time] Time instance.
       def initialize(zone:, is_24h:, time:)
         @zone = zone

--- a/lib/timex_datalink_client/protocol_1/time.rb
+++ b/lib/timex_datalink_client/protocol_1/time.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol1
+    class Time
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_TIME = [0x30]
+
+      attr_accessor :zone, :is_24h, :time
+
+      # Create a Time instance.
+      #
+      # @param zone [Integer] Time zone number (1 or 2).
+      # @param is_24h [Boolean] Toggle 24 hour time.
+      # @param time [::Time] Time to set (including time zone).
+      # @return [Time] Time instance.
+      def initialize(zone:, is_24h:, time:)
+        @zone = zone
+        @is_24h = is_24h
+        @time = time
+      end
+
+      # Compile packets for a time.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [
+          [
+            CPACKET_TIME,
+            zone,
+            time.hour,
+            time.min,
+            time.month,
+            time.day,
+            year_mod_1900,
+            wday_from_monday,
+            time.sec,
+            is_24h_value
+          ].flatten
+        ]
+      end
+
+      private
+
+      def year_mod_1900
+        time.year % 100
+      end
+
+      def wday_from_monday
+        (time.wday + 6) % 7
+      end
+
+      def is_24h_value
+        is_24h ? 2 : 1
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_1/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/time_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol1::Time do
+  let(:zone) { 1 }
+  let(:is_24h) { false }
+  let(:time) { Time.new(2015, 10, 21, 19, 28, 32) }
+
+  let(:time_instance) do
+    described_class.new(
+      zone: zone,
+      is_24h: is_24h,
+      time: time
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { time_instance.packets }
+
+    it_behaves_like "CRC-wrapped packets", [
+      [0x30, 0x01, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x02, 0x20, 0x01]
+    ]
+
+    context "when zone is 2" do
+      let(:zone) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x30, 0x02, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x02, 0x20, 0x01]
+      ]
+    end
+
+    context "when is_24h is true" do
+      let(:is_24h) { true }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x30, 0x01, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x02, 0x20, 0x02]
+      ]
+    end
+
+    context "when time is 2015-10-21 19:28:32" do
+      let(:time) { Time.new(1997, 9, 19, 19, 36, 55) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x30, 0x01, 0x13, 0x24, 0x09, 0x13, 0x61, 0x04, 0x37, 0x01]
+      ]
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_1/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/time_spec.rb
@@ -38,7 +38,7 @@ describe TimexDatalinkClient::Protocol1::Time do
       ]
     end
 
-    context "when time is 2015-10-21 19:28:32" do
+    context "when time is 1997-09-19 19:36:55" do
       let(:time) { Time.new(1997, 9, 19, 19, 36, 55) }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_1/end.rb",
     "lib/timex_datalink_client/protocol_1/start.rb",
     "lib/timex_datalink_client/protocol_1/sync.rb",
+    "lib/timex_datalink_client/protocol_3/time.rb",
 
     "lib/timex_datalink_client/protocol_3/alarm.rb",
     "lib/timex_datalink_client/protocol_3/eeprom.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/49!

This PR adds `Protocol1::Time` :tada: 

This is a little different than protocol 3.  It is used like this:

```ruby
time1 = Time.now + 1
time2 = time1.dup.utc

models = [
  TimexDatalinkClient::Protocol1::Sync.new(length: 50),
  TimexDatalinkClient::Protocol1::Start.new,
  TimexDatalinkClient::Protocol1::Time.new(zone: 1, is_24h: false, time: time1),
  TimexDatalinkClient::Protocol1::Time.new(zone: 2, is_24h: true, time: time2),
  TimexDatalinkClient::Protocol1::End.new
]

client = TimexDatalinkClient.new(
  serial_device: ARGV.first || "/dev/ttyACM0",
  models: models,
)

client.write
```