### PR TITLE
Add TimeName model for protocol 1

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -7,6 +7,7 @@ require "timex_datalink_client/protocol_1/end"
 require "timex_datalink_client/protocol_1/start"
 require "timex_datalink_client/protocol_1/sync"
 require "timex_datalink_client/protocol_1/time"
+require "timex_datalink_client/protocol_1/time_name"
 
 require "timex_datalink_client/protocol_3/alarm"
 require "timex_datalink_client/protocol_3/eeprom"

--- a/lib/timex_datalink_client/protocol_1/time_name.rb
+++ b/lib/timex_datalink_client/protocol_1/time_name.rb
@@ -17,7 +17,7 @@ class TimexDatalinkClient
       #
       # @param zone [Integer] Time zone number (1 or 2).
       # @param name [String] Name of time zone (3 chars max)
-      # @return [Time] Time instance.
+      # @return [TimeName] TimeName instance.
       def initialize(zone:, name:)
         @zone = zone
         @name = name

--- a/lib/timex_datalink_client/protocol_1/time_name.rb
+++ b/lib/timex_datalink_client/protocol_1/time_name.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/char_encoders"
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol1
+    class TimeName
+      include Helpers::CharEncoders
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_NAME = [0x31]
+
+      attr_accessor :zone, :name
+
+      # Create a TimeName instance.
+      #
+      # @param zone [Integer] Time zone number (1 or 2).
+      # @param name [String] Name of time zone (3 chars max)
+      # @return [Time] Time instance.
+      def initialize(zone:, name:)
+        @zone = zone
+        @name = name
+      end
+
+      # Compile packets for a time name.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [
+          [
+            CPACKET_NAME,
+            zone,
+            name_characters
+          ].flatten
+        ]
+      end
+
+      private
+
+      def name_characters
+        chars_for(name, length: 3, pad: true)
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol1::TimeName do
+  let(:zone) { 1 }
+  let(:name) { "CST" }
+
+  let(:time_instance) do
+    described_class.new(
+      zone: zone,
+      name: name
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { time_instance.packets }
+
+    it_behaves_like "CRC-wrapped packets", [
+      [0x31, 0x01, 0x0c, 0x1c, 0x1d]
+    ]
+
+    context "when zone is 2" do
+      let(:zone) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x02, 0x0c, 0x1c, 0x1d]
+      ]
+    end
+
+    context "when name is \"1\"" do
+      let(:name) { "1" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x01, 0x24, 0x24]
+      ]
+    end
+
+    context "when name is \"<>[" do
+      let(:name) { "<>[" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x3c, 0x3d, 0x3e]
+      ]
+    end
+
+    context "when name is \"Longer than 3 Characters\"" do
+      let(:name) { "Longer than 3 Characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x15, 0x18, 0x17]
+      ]
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_1/start.rb",
     "lib/timex_datalink_client/protocol_1/sync.rb",
     "lib/timex_datalink_client/protocol_3/time.rb",
+    "lib/timex_datalink_client/protocol_1/time_name.rb",
 
     "lib/timex_datalink_client/protocol_3/alarm.rb",
     "lib/timex_datalink_client/protocol_3/eeprom.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/50!

This PR adds `Protocol1::TimeName`!

Protocol 1 sets the time name separately from the time, so it's possible to update the name without changing the time:

```ruby
models = [
  TimexDatalinkClient::Protocol1::Sync.new,
  TimexDatalinkClient::Protocol1::Start.new,
  TimexDatalinkClient::Protocol1::TimeName.new(zone: 1, name: "one"),
  TimexDatalinkClient::Protocol1::TimeName.new(zone: 2, name: "two"),
  TimexDatalinkClient::Protocol1::End.new
]

client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models
)

client.write
```

Here's an example of how to set the time name to the time zone:

```ruby
time1 = Time.now
time2 = time1.dup.utc

models = [
  TimexDatalinkClient::Protocol1::Sync.new
  TimexDatalinkClient::Protocol1::Start.new,
  TimexDatalinkClient::Protocol1::Time.new(zone: 1, is_24h: false, time: time1),
  TimexDatalinkClient::Protocol1::Time.new(zone: 2, is_24h: true, time: time2),
  TimexDatalinkClient::Protocol1::TimeName.new(zone: 1, name: time1.zone),
  TimexDatalinkClient::Protocol1::TimeName.new(zone: 2, name: time2.zone),
  TimexDatalinkClient::Protocol1::End.new
]

client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models
)

client.write
```