### PR TITLE
Use protocol_1/time.rb file in gemspec for Protocol1::Time

### DIFF
--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_1/end.rb",
     "lib/timex_datalink_client/protocol_1/start.rb",
     "lib/timex_datalink_client/protocol_1/sync.rb",
-    "lib/timex_datalink_client/protocol_3/time.rb",
+    "lib/timex_datalink_client/protocol_1/time.rb",
     "lib/timex_datalink_client/protocol_1/time_name.rb",
 
     "lib/timex_datalink_client/protocol_3/alarm.rb",


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/54.

Quick fix to fix typo for file path in gemspec :bug: 