### PR TITLE
Fix date in description for protocol 3 Time spec

### DIFF
--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -53,7 +53,7 @@ describe TimexDatalinkClient::Protocol3::Time do
       ]
     end
 
-    context "when time is 2015-10-21 19:28:32 NZDT" do
+    context "when time is 1997-09-19 19:36:55 NZDT" do
       let(:tzinfo) { TZInfo::Timezone.get("Pacific/Auckland") }
       let(:time) { tzinfo.local_time(1997, 9, 19, 19, 36, 55) }
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/52 :+1: 

Quick fix to make spec description match the test data for a protocol 3 Time spec :lady_beetle: 