### PR TITLE
Allow paginate_cpackets helper method to paginate at a specified length

### DIFF
--- a/lib/timex_datalink_client/helpers/cpacket_paginator.rb
+++ b/lib/timex_datalink_client/helpers/cpacket_paginator.rb
@@ -3,10 +3,8 @@
 class TimexDatalinkClient
   class Helpers
     module CpacketPaginator
-      ITEMS_PER_PACKET = 32
-
-      def paginate_cpackets(header:, cpackets:)
-        paginated_cpackets = cpackets.each_slice(ITEMS_PER_PACKET)
+      def paginate_cpackets(header:, length:, cpackets:)
+        paginated_cpackets = cpackets.each_slice(length)
 
         paginated_cpackets.map.with_index(1) do |paginated_cpacket, index|
           header + [index] + paginated_cpacket

--- a/lib/timex_datalink_client/protocol_3/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_3/eeprom.rb
@@ -14,6 +14,7 @@ class TimexDatalinkClient
       CPACKET_DATA = [0x91, 0x01]
       CPACKET_END = [0x92, 0x01]
 
+      CPACKET_DATA_LENGTH = 32
       START_ADDRESS = 0x0236
       APPOINTMENT_NO_NOTIFICATION = 0xff
 
@@ -57,7 +58,7 @@ class TimexDatalinkClient
       end
 
       def payloads
-        paginate_cpackets(header: CPACKET_DATA, cpackets: all_packets)
+        paginate_cpackets(header: CPACKET_DATA, length: CPACKET_DATA_LENGTH, cpackets: all_packets)
       end
 
       def all_items

--- a/lib/timex_datalink_client/protocol_3/sound_theme.rb
+++ b/lib/timex_datalink_client/protocol_3/sound_theme.rb
@@ -13,6 +13,7 @@ class TimexDatalinkClient
       CPACKET_DATA = [0x91, 0x03]
       CPACKET_END = [0x92, 0x03]
 
+      CPACKET_DATA_LENGTH = 32
       SOUND_DATA_HEADER = "\x25\x04\x19\x69"
 
       attr_accessor :spc_file
@@ -41,7 +42,7 @@ class TimexDatalinkClient
       end
 
       def payloads
-        paginate_cpackets(header: CPACKET_DATA, cpackets: sound_theme_data.bytes)
+        paginate_cpackets(header: CPACKET_DATA, length: CPACKET_DATA_LENGTH, cpackets: sound_theme_data.bytes)
       end
 
       def sound_theme_data

--- a/lib/timex_datalink_client/protocol_3/wrist_app.rb
+++ b/lib/timex_datalink_client/protocol_3/wrist_app.rb
@@ -14,6 +14,7 @@ class TimexDatalinkClient
       CPACKET_DATA = [0x91, 0x02]
       CPACKET_END = [0x92, 0x02]
 
+      CPACKET_DATA_LENGTH = 32
       WRIST_APP_DELIMITER = /\xac.*\r\n/n
       WRIST_APP_CODE_INDEX = 8
 
@@ -43,7 +44,7 @@ class TimexDatalinkClient
       end
 
       def payloads
-        paginate_cpackets(header: CPACKET_DATA, cpackets: wrist_app_data.bytes)
+        paginate_cpackets(header: CPACKET_DATA, length: CPACKET_DATA_LENGTH, cpackets: wrist_app_data.bytes)
       end
 
       def wrist_app_data


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/58!

This PR adds an `length` parameter to the `paginate_cpackets` helper method from the `CpacketPaginator` module.  The Timex Datalink software paginates at 27 bytes for protocol 1 EEPROM data, so this will let this method be used for that, too.