### PR TITLE
Remove MESSAGE_LENGTH from Protocol3::Alarm

### DIFF
--- a/lib/timex_datalink_client/protocol_3/alarm.rb
+++ b/lib/timex_datalink_client/protocol_3/alarm.rb
@@ -11,8 +11,6 @@ class TimexDatalinkClient
 
       CPACKET_ALARM = [0x50]
 
-      MESSAGE_LENGTH = 8
-
       attr_accessor :number, :audible, :time, :message
 
       # Create an Alarm instance.


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/64.

Quick PR to remove `MESSAGE_LENGTH` from `Protocol3::Alarm`.  It's not used anywhere, so it can simply be removed.