### PR TITLE
Use 0.008 byte_sleep in README.md performance tuning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ reliably with the [Teensy LC Notebook Adapter](https://github.com/synthead/timex
 timex_datalink_client = TimexDatalinkClient.new(
   serial_device: "/dev/ttyACM0",
   models: models,
-  byte_sleep: 0.006,
+  byte_sleep: 0.008,
   packet_sleep: 0.06,
   verbose: true
 )


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/69! :ok_hand: 

This PR documents a byte_sleep value of 0.008 in the performance tuning section of `README.md`.

As described in the issue:

> On the Timex 70301 (Datalink 50) and Franklin Rolodex Flash PC Companion RFLS-8 (which are both protocol 1 devices), the 0.006 byte_sleep option is a little too aggressive and doesn't seem to work most of the time. I haven't seen 0.008 fail with these devices yet with any device, and this difference is hardly noticeable.