### PR TITLE
Add sync start and end models for protocol 9

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -26,6 +26,10 @@ require "timex_datalink_client/protocol_3/sync"
 require "timex_datalink_client/protocol_3/time"
 require "timex_datalink_client/protocol_3/wrist_app"
 
+require "timex_datalink_client/protocol_9/end"
+require "timex_datalink_client/protocol_9/start"
+require "timex_datalink_client/protocol_9/sync"
+
 class TimexDatalinkClient
   attr_accessor :serial_device, :models, :byte_sleep, :packet_sleep, :verbose
 

--- a/lib/timex_datalink_client/protocol_9/end.rb
+++ b/lib/timex_datalink_client/protocol_9/end.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol9
+    class End
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_SKIP = [0x21]
+
+      # Compile packets for data end command.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [CPACKET_SKIP]
+      end
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_9/start.rb
+++ b/lib/timex_datalink_client/protocol_9/start.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol9
+    class Start
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_START = [0x20, 0x00, 0x00, 0x09]
+
+      # Compile packets for data start command.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [CPACKET_START]
+      end
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_9/sync.rb
+++ b/lib/timex_datalink_client/protocol_9/sync.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class TimexDatalinkClient
+  class Protocol9
+    class Sync
+      SYNC_1_BYTE = [0x55]
+      SYNC_2_BYTE = [0xaa]
+
+      SYNC_2_LENGTH = 40
+
+      attr_accessor :length
+
+      # Create a Sync instance.
+      #
+      # @param length [Integer] Number of 0x55 sync bytes to use.
+      # @return [Sync] Sync instance.
+      def initialize(length: 300)
+        @length = length
+      end
+
+      # Compile packets for syncronization data.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [render_sync_1 + render_sync_2]
+      end
+
+      private
+
+      def render_sync_1
+        SYNC_1_BYTE * length
+      end
+
+      def render_sync_2
+        SYNC_2_BYTE * SYNC_2_LENGTH
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_9/end_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/end_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol9::End do
+  let(:end_instance) { described_class.new }
+
+  describe "#packets", :crc do
+    subject(:packets) { end_instance.packets }
+
+    it_behaves_like "CRC-wrapped packets", [[0x21]]
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_9/start_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/start_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol9::Start do
+  let(:start) { described_class.new }
+
+  describe "#packets", :crc do
+    subject(:packets) { start.packets }
+
+    it_behaves_like "CRC-wrapped packets", [[0x20, 0x00, 0x00, 0x09]]
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_9/sync_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/sync_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol9::Sync do
+  let(:length) { 200 }
+  let(:sync) { described_class.new(length: length) }
+
+  describe "#packets" do
+    subject(:packets) { sync.packets }
+
+    it { should eq([[0x55] * length + [0xaa] * 40]) }
+
+    context "when length is 350" do
+      let(:length) { 350 }
+
+      it { should eq([[0x55] * length + [0xaa] * 40]) }
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -42,7 +42,11 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_3/start.rb",
     "lib/timex_datalink_client/protocol_3/sync.rb",
     "lib/timex_datalink_client/protocol_3/time.rb",
-    "lib/timex_datalink_client/protocol_3/wrist_app.rb"
+    "lib/timex_datalink_client/protocol_3/wrist_app.rb",
+
+    "lib/timex_datalink_client/protocol_9/end.rb",
+    "lib/timex_datalink_client/protocol_9/start.rb",
+    "lib/timex_datalink_client/protocol_9/sync.rb"
   ]
 
   s.add_dependency "crc", "~> 0.4.2"


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/75!

Adds `Sync`, `Start`, and `End` classes for protocol 9!  This works with the Timex 78701 Ironman Triathlon watch.