### PR TITLE
Add Time and TimeName models to protocol 9

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -29,6 +29,8 @@ require "timex_datalink_client/protocol_3/wrist_app"
 require "timex_datalink_client/protocol_9/end"
 require "timex_datalink_client/protocol_9/start"
 require "timex_datalink_client/protocol_9/sync"
+require "timex_datalink_client/protocol_9/time"
+require "timex_datalink_client/protocol_9/time_name"
 
 class TimexDatalinkClient
   attr_accessor :serial_device, :models, :byte_sleep, :packet_sleep, :verbose

--- a/lib/timex_datalink_client/protocol_9/time.rb
+++ b/lib/timex_datalink_client/protocol_9/time.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol9
+    class Time
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_TIME = [0x30]
+
+      attr_accessor :zone, :is_24h, :time
+
+      # Create a Time instance.
+      #
+      # @param zone [Integer] Time zone number (1 or 2).
+      # @param is_24h [Boolean] Toggle 24 hour time.
+      # @param time [::Time] Time to set.
+      # @return [Time] Time instance.
+      def initialize(zone:, is_24h:, time:)
+        @zone = zone
+        @is_24h = is_24h
+        @time = time
+      end
+
+      # Compile packets for a time.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [
+          [
+            CPACKET_TIME,
+            zone,
+            time.hour,
+            time.min,
+            time.month,
+            time.day,
+            year_mod_1900,
+            wday_from_monday,
+            time.sec,
+            is_24h_value
+          ].flatten
+        ]
+      end
+
+      private
+
+      def year_mod_1900
+        time.year % 100
+      end
+
+      def wday_from_monday
+        (time.wday + 6) % 7
+      end
+
+      def is_24h_value
+        is_24h ? 2 : 1
+      end
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_9/time_name.rb
+++ b/lib/timex_datalink_client/protocol_9/time_name.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/char_encoders"
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol9
+    class TimeName
+      include Helpers::CharEncoders
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_NAME = [0x31]
+
+      attr_accessor :zone, :name
+
+      # Create a TimeName instance.
+      #
+      # @param zone [Integer] Time zone number (1 or 2).
+      # @param name [String] Name of time zone (3 chars max)
+      # @return [TimeName] TimeName instance.
+      def initialize(zone:, name:)
+        @zone = zone
+        @name = name
+      end
+
+      # Compile packets for a time name.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [
+          [
+            CPACKET_NAME,
+            zone,
+            name_characters
+          ].flatten
+        ]
+      end
+
+      private
+
+      def name_characters
+        chars_for(name, length: 3, pad: true)
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol9::TimeName do
+  let(:zone) { 1 }
+  let(:name) { "CST" }
+
+  let(:time_instance) do
+    described_class.new(
+      zone: zone,
+      name: name
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { time_instance.packets }
+
+    it_behaves_like "CRC-wrapped packets", [
+      [0x31, 0x01, 0x0c, 0x1c, 0x1d]
+    ]
+
+    context "when zone is 2" do
+      let(:zone) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x02, 0x0c, 0x1c, 0x1d]
+      ]
+    end
+
+    context "when name is \"1\"" do
+      let(:name) { "1" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x01, 0x24, 0x24]
+      ]
+    end
+
+    context "when name is \"<>[" do
+      let(:name) { "<>[" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x3c, 0x3d, 0x3e]
+      ]
+    end
+
+    context "when name is \"Longer than 3 Characters\"" do
+      let(:name) { "Longer than 3 Characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x15, 0x18, 0x17]
+      ]
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_9/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/time_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol9::Time do
+  let(:zone) { 1 }
+  let(:is_24h) { false }
+  let(:time) { Time.new(2015, 10, 21, 19, 28, 32) }
+
+  let(:time_instance) do
+    described_class.new(
+      zone: zone,
+      is_24h: is_24h,
+      time: time
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { time_instance.packets }
+
+    it_behaves_like "CRC-wrapped packets", [
+      [0x30, 0x01, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x02, 0x20, 0x01]
+    ]
+
+    context "when zone is 2" do
+      let(:zone) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x30, 0x02, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x02, 0x20, 0x01]
+      ]
+    end
+
+    context "when is_24h is true" do
+      let(:is_24h) { true }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x30, 0x01, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x02, 0x20, 0x02]
+      ]
+    end
+
+    context "when time is 1997-09-19 19:36:55" do
+      let(:time) { Time.new(1997, 9, 19, 19, 36, 55) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x30, 0x01, 0x13, 0x24, 0x09, 0x13, 0x61, 0x04, 0x37, 0x01]
+      ]
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -46,7 +46,9 @@ Gem::Specification.new do |s|
 
     "lib/timex_datalink_client/protocol_9/end.rb",
     "lib/timex_datalink_client/protocol_9/start.rb",
-    "lib/timex_datalink_client/protocol_9/sync.rb"
+    "lib/timex_datalink_client/protocol_9/sync.rb",
+    "lib/timex_datalink_client/protocol_9/time.rb",
+    "lib/timex_datalink_client/protocol_9/time_name.rb"
   ]
 
   s.add_dependency "crc", "~> 0.4.2"


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/77.

The packet format is identical to protocol 1, so the models and specs are copied and modified to live in `Protocol9` :+1: 