### PR TITLE
Add SoundOptions model to protocol 9

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -27,6 +27,7 @@ require "timex_datalink_client/protocol_3/time"
 require "timex_datalink_client/protocol_3/wrist_app"
 
 require "timex_datalink_client/protocol_9/end"
+require "timex_datalink_client/protocol_9/sound_options"
 require "timex_datalink_client/protocol_9/start"
 require "timex_datalink_client/protocol_9/sync"
 require "timex_datalink_client/protocol_9/time"

--- a/lib/timex_datalink_client/protocol_9/sound_options.rb
+++ b/lib/timex_datalink_client/protocol_9/sound_options.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol9
+    class SoundOptions
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_BEEPS = [0x32]
+
+      attr_accessor :hourly_chime, :button_beep
+
+      # Create a SoundOptions instance.
+      #
+      # @param hourly_chime [Boolean] Toggle hourly chime sounds.
+      # @param button_beep [Boolean] Toggle button beep sounds.
+      # @return [SoundOptions] SoundOptions instance.
+      def initialize(hourly_chime:, button_beep:)
+        @hourly_chime = hourly_chime
+        @button_beep = button_beep
+      end
+
+      # Compile packets for sound options.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [
+          CPACKET_BEEPS + [hourly_chime_value + button_beep_value]
+        ]
+      end
+
+      def hourly_chime_value
+        hourly_chime ? 1 : 0
+      end
+
+      def button_beep_value
+        button_beep ? 2 : 0
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_9/sound_options_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/sound_options_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol9::SoundOptions do
+  let(:hourly_chime) { false }
+  let(:button_beep) { false }
+
+  let(:sound_options) do
+    described_class.new(
+      hourly_chime: hourly_chime,
+      button_beep: button_beep
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { sound_options.packets }
+
+    it_behaves_like "CRC-wrapped packets", [[0x32, 0x00]]
+
+    context "when hourly chime is enabled" do
+      let(:hourly_chime) { true }
+
+      it_behaves_like "CRC-wrapped packets", [[0x32, 0x01]]
+    end
+
+    context "when button beep is enabled" do
+      let(:button_beep) { true }
+
+      it_behaves_like "CRC-wrapped packets", [[0x32, 0x02]]
+    end
+
+    context "when hourly chime and button beep are enabled" do
+      let(:hourly_chime) { true }
+      let(:button_beep) { true }
+
+      it_behaves_like "CRC-wrapped packets", [[0x32, 0x03]]
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_3/wrist_app.rb",
 
     "lib/timex_datalink_client/protocol_9/end.rb",
+    "lib/timex_datalink_client/protocol_9/sound_options.rb",
     "lib/timex_datalink_client/protocol_9/start.rb",
     "lib/timex_datalink_client/protocol_9/sync.rb",
     "lib/timex_datalink_client/protocol_9/time.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/79!

Adds `Protocol9::SoundOptions` :tada: 