### PR TITLE
Add Timer model to protocol 9

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -33,6 +33,7 @@ require "timex_datalink_client/protocol_9/start"
 require "timex_datalink_client/protocol_9/sync"
 require "timex_datalink_client/protocol_9/time"
 require "timex_datalink_client/protocol_9/time_name"
+require "timex_datalink_client/protocol_9/timer"
 
 class TimexDatalinkClient
   attr_accessor :serial_device, :models, :byte_sleep, :packet_sleep, :verbose

--- a/lib/timex_datalink_client/protocol_9/timer.rb
+++ b/lib/timex_datalink_client/protocol_9/timer.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/char_encoders"
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol9
+    class Timer
+      include Helpers::CharEncoders
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_TIMER = [0x43]
+
+      attr_accessor :number, :label, :time, :action_at_end
+
+      # Create a Timer instance.
+      #
+      # @param number [Integer] Entry number for timer.
+      # @param label [String] Label for timer.
+      # @param time [Time] Time of timer.
+      # @param action_at_end [Integer] Action at end of timer.
+      # @return [Timer] Timer instance.
+      def initialize(number:, label:, time:, action_at_end:)
+        @number = number
+        @label = label
+        @time = time
+        @action_at_end = action_at_end
+      end
+
+      # Compile packets for a timer.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [
+          [
+            CPACKET_TIMER,
+            number,
+            time.hour,
+            time.min,
+            time.sec,
+            action_at_end,
+            label_characters
+          ].flatten
+        ]
+      end
+
+      private
+
+      def label_characters
+        chars_for(label, length: 8, pad: true)
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol9::Timer do
+  let(:number) { 1 }
+  let(:label) { "Timer 1" }
+  let(:time) { Time.new(0, 1, 1, 1, 2, 3) }
+  let(:action_at_end) { 0 }
+
+  let(:timer) do
+    described_class.new(
+      number: number,
+      label: label,
+      time: time,
+      action_at_end: action_at_end
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { timer.packets }
+
+    it_behaves_like "CRC-wrapped packets", [
+      [0x43, 0x01, 0x01, 0x02, 0x03, 0x00, 0x1d, 0x12, 0x16, 0x0e, 0x1b, 0x24, 0x01, 0x24]
+    ]
+
+    context "when number is 2" do
+      let(:number) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x43, 0x02, 0x01, 0x02, 0x03, 0x00, 0x1d, 0x12, 0x16, 0x0e, 0x1b, 0x24, 0x01, 0x24]
+      ]
+    end
+
+    context "when label is \"Timer with More than 8 Characters\"" do
+      let(:label) { "Wake Up with More than 8 Characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x43, 0x01, 0x01, 0x02, 0x03, 0x00, 0x20, 0x0a, 0x14, 0x0e, 0x24, 0x1e, 0x19, 0x24]
+      ]
+    end
+
+    context "when label is \";@_|<>[]" do
+      let(:label) { ";@_|<>[]" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x43, 0x01, 0x01, 0x02, 0x03, 0x00, 0x36, 0x38, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f]
+      ]
+    end
+
+    context "when label is \"~with~invalid~characters\"" do
+      let(:label) { "~with~invalid~characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x43, 0x01, 0x01, 0x02, 0x03, 0x00, 0x24, 0x20, 0x12, 0x1d, 0x11, 0x24, 0x12, 0x17]
+      ]
+    end
+
+    context "when time is 16:35:12" do
+      let(:time) { Time.new(0, 1, 1, 16, 35, 12) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x43, 0x01, 0x10, 0x23, 0x0c, 0x00, 0x1d, 0x12, 0x16, 0x0e, 0x1b, 0x24, 0x01, 0x24]
+      ]
+    end
+
+    context "when action_at_end is 2" do
+      let(:action_at_end) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x43, 0x01, 0x01, 0x02, 0x03, 0x02, 0x1d, 0x12, 0x16, 0x0e, 0x1b, 0x24, 0x01, 0x24]
+      ]
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -50,7 +50,8 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_9/start.rb",
     "lib/timex_datalink_client/protocol_9/sync.rb",
     "lib/timex_datalink_client/protocol_9/time.rb",
-    "lib/timex_datalink_client/protocol_9/time_name.rb"
+    "lib/timex_datalink_client/protocol_9/time_name.rb",
+    "lib/timex_datalink_client/protocol_9/timer.rb"
   ]
 
   s.add_dependency "crc", "~> 0.4.2"


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/83!

Adds `Timer` to the protocol 9 models!  This is a unique to the Ironman watch.  The original GUI client looks like this:

![image](https://user-images.githubusercontent.com/820984/189861960-fb1605b1-b528-47d1-aca1-538c9a44d166.png)