### PR TITLE
Add missing escaped quotes in spec descriptions

### DIFF
--- a/spec/lib/timex_datalink_client/eeprom/anniversary_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/anniversary_spec.rb
@@ -39,7 +39,7 @@ describe TimexDatalinkClient::Eeprom::Anniversary do
       ]
     end
 
-    context "when anniversary is \";@_|<>[]" do
+    context "when anniversary is \";@_|<>[]\"" do
       let(:anniversary) { ";@_|<>[]" }
 
       it_behaves_like "a length-prefixed packet", [

--- a/spec/lib/timex_datalink_client/eeprom/appointment_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/appointment_spec.rb
@@ -37,7 +37,7 @@ describe TimexDatalinkClient::Eeprom::Appointment do
       ]
     end
 
-    context "when message is \";@_|<>[]" do
+    context "when message is \";@_|<>[]\"" do
       let(:message) { ";@_|<>[]" }
 
       it_behaves_like "a length-prefixed packet", [

--- a/spec/lib/timex_datalink_client/eeprom/list_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/list_spec.rb
@@ -37,7 +37,7 @@ describe TimexDatalinkClient::Eeprom::List do
       ]
     end
 
-    context "when list_entry is \";@_|<>[]" do
+    context "when list_entry is \";@_|<>[]\"" do
       let(:list_entry) { ";@_|<>[]" }
 
       it_behaves_like "a length-prefixed packet", [

--- a/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
@@ -31,7 +31,7 @@ describe TimexDatalinkClient::Eeprom::PhoneNumber do
       ]
     end
 
-    context "when name is \";@_|<>[]" do
+    context "when name is \";@_|<>[]\"" do
       let(:name) { ";@_|<>[]" }
 
       it_behaves_like "a length-prefixed packet", [

--- a/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
@@ -64,7 +64,7 @@ describe TimexDatalinkClient::Protocol1::Alarm do
       ]
     end
 
-    context "when message is \";@_|<>[]" do
+    context "when message is \";@_|<>[]\"" do
       let(:message) { ";@_|<>[]" }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/spec/lib/timex_datalink_client/protocol_3/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/alarm_spec.rb
@@ -56,7 +56,7 @@ describe TimexDatalinkClient::Protocol3::Alarm do
       ]
     end
 
-    context "when message is \";@_|<>[]" do
+    context "when message is \";@_|<>[]\"" do
       let(:message) { ";@_|<>[]" }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
@@ -75,7 +75,7 @@ describe TimexDatalinkClient::Protocol9::Alarm do
       ]
     end
 
-    context "when message is \";@_|<>[]" do
+    context "when message is \";@_|<>[]\"" do
       let(:message) { ";@_|<>[]" }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
@@ -40,7 +40,7 @@ describe TimexDatalinkClient::Protocol9::Timer do
       ]
     end
 
-    context "when label is \";@_|<>[]" do
+    context "when label is \";@_|<>[]\"" do
       let(:label) { ";@_|<>[]" }
 
       it_behaves_like "CRC-wrapped packets", [


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/92.

Adds an escaped quote to a handful of spec descriptions that are missing them :+1: 