### PR TITLE
Use uppercare "H" type in Eeprom::PhoneNumber spec.

### DIFF
--- a/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
@@ -73,7 +73,7 @@ describe TimexDatalinkClient::Eeprom::PhoneNumber do
     end
 
     context "when type is \"H\"" do
-      let(:type) { "h" }
+      let(:type) { "H" }
 
       it_behaves_like "a length-prefixed packet", [
         0x21, 0x43, 0x65, 0x87, 0x09, 0xcf, 0x96, 0xb2, 0x75, 0x22, 0x69, 0x31, 0x4f, 0x25, 0xfe


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/94.

Uses "H" type value in spec, as described in the spec description.