### PR TITLE
Remove trailing commas in a few places

### DIFF
--- a/lib/timex_datalink_client/eeprom/phone_number.rb
+++ b/lib/timex_datalink_client/eeprom/phone_number.rb
@@ -31,7 +31,7 @@ class TimexDatalinkClient
       def packet
         [
           number_with_type_characters,
-          name_characters,
+          name_characters
         ].flatten
       end
 

--- a/lib/timex_datalink_client/protocol_9/alarm.rb
+++ b/lib/timex_datalink_client/protocol_9/alarm.rb
@@ -44,7 +44,7 @@ class TimexDatalinkClient
             month.to_i,
             day.to_i,
             audible_integer,
-            message_characters,
+            message_characters
           ].flatten
         ]
       end

--- a/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
+++ b/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb
@@ -11,7 +11,7 @@ describe TimexDatalinkClient::Eeprom::PhoneNumber do
     described_class.new(
       name: name,
       number: number,
-      type: type,
+      type: type
     )
   end
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/96.

Removes a few trailing commas.