### PR TITLE
Remove extra truncate logic from Eeprom::PhoneNumber

### DIFF
--- a/lib/timex_datalink_client/eeprom/phone_number.rb
+++ b/lib/timex_datalink_client/eeprom/phone_number.rb
@@ -37,15 +37,13 @@ class TimexDatalinkClient
 
       private
 
-      def number_with_type_truncated
+      def number_with_type_padded
         number_with_type = "#{number} #{type}"
-        padded_number_with_type = number_with_type.rjust(PHONE_DIGITS)
-
-        padded_number_with_type[0..PHONE_DIGITS - 1]
+        number_with_type.rjust(PHONE_DIGITS)
       end
 
       def number_with_type_characters
-        phone_chars_for(number_with_type_truncated)
+        phone_chars_for(number_with_type_padded)
       end
 
       def name_characters


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/98.

Removes extra truncate logic from Eeprom::PhoneNumber.  This is already being achieved with `phone_chars_for`:

https://github.com/synthead/timex_datalink_client/blob/51bdc98ec56cd014b03c5ce94370f55318cb3096/lib/timex_datalink_client/helpers/char_encoders.rb#L32-L40

Tests are already in place to ensure that long numbers are truncated, too:

https://github.com/synthead/timex_datalink_client/blob/2120ceefd47f2d14a9a50e3d4666bc6053821ff6/spec/lib/timex_datalink_client/eeprom/phone_number_spec.rb#L59-L65