### PR TITLE
Mention protocol 9 support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ These devices have been tested to work with this library:
 
 - Timex 70301 (Datalink 50, protocol 1)
 - Timex 69737 (Datalink 150, protocol 3)
+- Timex 78701 (Ironman Triathlon, protocol 9)
 - Franklin Rolodex Flash PC Companion RFLS-8 (protocol 1)
 
 Protocol 4 is not currently supported.  The only known product to use this protocol is the Timex Datalink 150s.  This

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ below to identify the protcol.
 |![image](https://user-images.githubusercontent.com/820984/189607899-5bb67438-1c82-41e0-95d1-d1134cfb1f8b.png)|Use protocol 1 models in `TimexDatalinkClient::Protocol1`|
 |![image](https://user-images.githubusercontent.com/820984/189609399-25eea5c5-958e-489d-936e-139342c9fddf.png)|Use protocol 3 models in `TimexDatalinkClient::Protocol3`|
 |![image](https://user-images.githubusercontent.com/820984/189609671-33a6dc6b-1eb1-4942-8bac-238e6056d1c2.png)|Protocol 4 (currently not supported)|
+|![image](https://user-images.githubusercontent.com/820984/190122029-6df17bd0-171a-425c-ac63-d415eeb9fffd.png)|Use protocol 9 models in `TimexDatalinkClient::Protocol9`|
 
 During data transmission, the "start" packet of each protocol will announce the protocol number to the device.  If the
 protocol doesn't match the device, the screen will display "PC-WATCH MISMATCH" and safely abort the data transmission.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Timex Datalink library for Ruby
 
 Here is a fully-tested, feature-complete, and byte-for-byte perfect reimplementation of the Timex Datalink client
-software as a Ruby library!  This library supports protocol version 1 and 3, which covers almost every Timex Datalink
+software as a Ruby library!  This library supports protocols 1, 3, and 9, which covers almost every Timex Datalink
 device!
 
 These devices have been tested to work with this library:


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/102!

This PR updates `README.md` to mention support for protocol 9.