### PR TITLE
Mention protocol 6 is unsupported in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ below to identify the protcol.
 |![image](https://user-images.githubusercontent.com/820984/189609399-25eea5c5-958e-489d-936e-139342c9fddf.png)|Use protocol 3 models in `TimexDatalinkClient::Protocol3`|
 |![image](https://user-images.githubusercontent.com/820984/189609671-33a6dc6b-1eb1-4942-8bac-238e6056d1c2.png)|Protocol 4 (currently not supported)|
 |![image](https://user-images.githubusercontent.com/820984/190122029-6df17bd0-171a-425c-ac63-d415eeb9fffd.png)|Use protocol 9 models in `TimexDatalinkClient::Protocol9`|
+|![image](https://user-images.githubusercontent.com/820984/190326340-3ffba239-ea9e-4595-83ae-c261be284a30.png)|Protocol 6 (currently not supported)|
 
 During data transmission, the "start" packet of each protocol will announce the protocol number to the device.  If the
 protocol doesn't match the device, the screen will display "PC-WATCH MISMATCH" and safely abort the data transmission.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ These devices have been tested to work with this library:
 - Timex 78701 (Ironman Triathlon, protocol 9)
 - Franklin Rolodex Flash PC Companion RFLS-8 (protocol 1)
 
-Protocol 4 is not currently supported.  The only known product to use this protocol is the Timex Datalink 150s.  This
-may be supported sometime in the future.
+Protocols 4 and 6 are not currently supported.  The Timex Datalink 150s uses protocol 4, and the Motorola Beepwear Pro
+uses protocol 6.  These are the only devices known to use these protocols.  They might be supported sometime in the
+future!
 
 ## What is the Timex Datalink?
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/104.

Mentions that protocol 6, identified by "V5.0", is not supported by this library.  The only device that uses this is the Motorola Beepwear Pro.  It probably has special packets for the pager functionality, but I don't have a device to test anything.