### PR TITLE
Bump to version 0.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timex_datalink_client (0.5.0)
+    timex_datalink_client (0.6.0)
       crc (~> 0.4.2)
       rubyserial (~> 0.6.0)
 

--- a/lib/timex_datalink_client/version.rb
+++ b/lib/timex_datalink_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class TimexDatalinkClient
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/lib/timex_datalink_client_spec.rb
+++ b/spec/lib/timex_datalink_client_spec.rb
@@ -71,7 +71,7 @@ describe TimexDatalinkClient do
   describe "VERSION" do
     subject(:version) { described_class::VERSION }
 
-    it { should eq("0.5.0") }
+    it { should eq("0.6.0") }
   end
 
   describe "#write" do


### PR DESCRIPTION
This PR bumps the version to 0.6.0! :tada: 

Notably, this release includes support for protocol 9, which includes the Timex Ironman Triathlon watches.