### PR TITLE
Use 8 laps in example for protocol 9 documentation

### DIFF
--- a/docs/timex_ironman_triathlon_protocol_9.md
+++ b/docs/timex_ironman_triathlon_protocol_9.md
@@ -225,7 +225,7 @@ phone_numbers = [
 
 chrono = TimexDatalinkClient::Protocol9::Eeprom::Chrono.new(
   label: "CHRONO",
-  laps: 0
+  laps: 8
 )
 
 time1 = Time.now


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/116!

This PR uses 8 laps in both examples of the protocol 9 documentation.