### PR TITLE
Sort requires in TimexDatalinkClient

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "timex_datalink_client/version"
 require "timex_datalink_client/notebook_adapter"
+require "timex_datalink_client/version"
 
 require "timex_datalink_client/protocol_1/alarm"
 require "timex_datalink_client/protocol_1/eeprom"


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/118.

Quick PR to sort requires in `TimexDatalinkClient`.