### PR TITLE
Add protocol 4 alarm

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -29,6 +29,7 @@ require "timex_datalink_client/protocol_3/sync"
 require "timex_datalink_client/protocol_3/time"
 require "timex_datalink_client/protocol_3/wrist_app"
 
+require "timex_datalink_client/protocol_4/alarm"
 require "timex_datalink_client/protocol_4/end"
 require "timex_datalink_client/protocol_4/start"
 require "timex_datalink_client/protocol_4/sync"

--- a/lib/timex_datalink_client/protocol_4/alarm.rb
+++ b/lib/timex_datalink_client/protocol_4/alarm.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/char_encoders"
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol4
+    class Alarm
+      include Helpers::CharEncoders
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_ALARM = [0x50]
+
+      attr_accessor :number, :audible, :time, :message
+
+      # Create an Alarm instance.
+      #
+      # @param number [Integer] Alarm number (from 1 to 5).
+      # @param audible [Boolean] Toggle alarm sounds.
+      # @param time [::Time] Time of alarm.
+      # @param message [String] Alarm message text.
+      # @return [Alarm] Alarm instance.
+      def initialize(number:, audible:, time:, message:)
+        @number = number
+        @audible = audible
+        @time = time
+        @message = message
+      end
+
+      # Compile packets for an alarm.
+      #
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        [
+          [
+            CPACKET_ALARM,
+            number,
+            time.hour,
+            time.min,
+            0,
+            0,
+            message_characters,
+            audible_integer
+          ].flatten
+        ]
+      end
+
+      private
+
+      def message_characters
+        chars_for(message, length: 8, pad: true)
+      end
+
+      def audible_integer
+        audible ? 1 : 0
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_4/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/alarm_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol4::Alarm do
+  let(:number) { 1 }
+  let(:audible) { false }
+  let(:time) { Time.new(1994) }
+  let(:message) { "Alarm 1" }
+
+  let(:alarm) do
+    described_class.new(
+      number: number,
+      audible: audible,
+      time: time,
+      message: message
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { alarm.packets }
+
+    it_behaves_like "CRC-wrapped packets", [
+      [0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x00]
+    ]
+
+    context "when number is 2" do
+      let(:number) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x50, 0x02, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x00]
+      ]
+    end
+
+    context "when audible is true" do
+      let(:audible) { true }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x01]
+      ]
+    end
+
+    context "when time is 16:35" do
+      let(:time) { Time.new(1994, 1, 1, 16, 35) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x50, 0x01, 0x10, 0x23, 0x00, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x00]
+      ]
+    end
+
+    context "when message is \"Wake Up with More than 8 Characters\"" do
+      let(:message) { "Wake Up with More than 8 Characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x20, 0x0a, 0x14, 0x0e, 0x24, 0x1e, 0x19, 0x24, 0x00]
+      ]
+    end
+
+    context "when message is \";@_|<>[]\"" do
+      let(:message) { ";@_|<>[]" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x36, 0x38, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x00]
+      ]
+    end
+
+    context "when message is \"~with~invalid~characters\"" do
+      let(:message) { "~with~invalid~characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x24, 0x20, 0x12, 0x1d, 0x11, 0x24, 0x12, 0x17, 0x00]
+      ]
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_3/time.rb",
     "lib/timex_datalink_client/protocol_3/wrist_app.rb",
 
+    "lib/timex_datalink_client/protocol_4/alarm.rb",
     "lib/timex_datalink_client/protocol_4/end.rb",
     "lib/timex_datalink_client/protocol_4/start.rb",
     "lib/timex_datalink_client/protocol_4/sync.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/123!

Adds `Protocol4::Alarm`.  This is identical to `Protocol3::Alarm`.