### PR TITLE
Document protocol 4 models in TimexDatalinkClient#initialize

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -64,8 +64,10 @@ class TimexDatalinkClient
   # @param models [Array<Protocol1::Sync, Protocol1::Start, Protocol1::Time, Protocol1::TimeName, Protocol1::Alarm,
   #   Protocol1::Eeprom, Protocol1::End, Protocol3::Sync, Protocol3::Start, Protocol3::Time, Protocol3::Alarm,
   #   Protocol3::Eeprom, Protocol3::SoundTheme, Protocol3::SoundOptions, Protocol3::WristApp, Protocol3::End,
-  #   Protocol9::Sync, Protocol9::Start, Protocol9::Time, Protocol9::TimeName, Protocol9::Timer, Protocol9::Alarm,
-  #   Protocol9::Eeprom, Protocol9::SoundOptions, Protocol9::End>] Models to compile data for.
+  #   Protocol4::Sync, Protocol4::Start, Protocol4::Time, Protocol4::Alarm, Protocol4::Eeprom, Protocol4::SoundTheme,
+  #   Protocol4::SoundOptions, Protocol4::WristApp, Protocol4::End, Protocol9::Sync, Protocol9::Start, Protocol9::Time,
+  #   Protocol9::TimeName, Protocol9::Timer, Protocol9::Alarm, Protocol9::Eeprom, Protocol9::SoundOptions,
+  #   Protocol9::End>] Models to compile data for.
   # @param byte_sleep [Integer, nil] Time to sleep after sending byte.
   # @param packet_sleep [Integer, nil] Time to sleep after sending packet of bytes.
   # @param verbose [Boolean] Write verbose output to console.


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/135!

This PR adds YARDoc documentation to document that protocol 4 model classes are supported in the `models` parameter for `TimexDatalinkClient#initialize`.

Here's a screenshot of the documentation at work in the browser:

![image](https://user-images.githubusercontent.com/820984/201589558-b2bd69b8-d8ec-40e8-b623-7a3463b27526.png)