### PR TITLE
Use Timex model names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ device!
 
 These devices have been tested to work with this library:
 
-- Timex 70301 (Datalink 50, protocol 1)
-- Timex 69737 (Datalink 150, protocol 3)
-- Timex 78701 (Ironman Triathlon, protocol 9)
+- Timex Datalink 50 (protocol 1)
+- Timex Datalink 70 (protocol 1)
+- Timex Datalink 150 (protocol 3)
+- Timex Ironman Triathlon (protocol 9)
 - Franklin Rolodex Flash PC Companion RFLS-8 (protocol 1)
 - Royal FL95 PC Organizer (protocol 1)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These devices have been tested to work with this library:
 - Timex Datalink 50 (protocol 1)
 - Timex Datalink 70 (protocol 1)
 - Timex Datalink 150 (protocol 3)
+- Timex Datalink 150s (protocol 4)
 - Timex Ironman Triathlon (protocol 9)
 - Franklin Rolodex Flash PC Companion RFLS-8 (protocol 1)
 - Royal FL95 PC Organizer (protocol 1)


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/142!

This PR updates README.md to use only the Timex model names in the supported devices list.  This makes the supported devices much clearer to understand, and focuses more on the protocol support in this library.