### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timex_datalink_client (0.6.0)
+    timex_datalink_client (0.7.0)
       crc (~> 0.4.2)
       rubyserial (~> 0.6.0)
 

--- a/lib/timex_datalink_client/version.rb
+++ b/lib/timex_datalink_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class TimexDatalinkClient
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/spec/lib/timex_datalink_client_spec.rb
+++ b/spec/lib/timex_datalink_client_spec.rb
@@ -71,7 +71,7 @@ describe TimexDatalinkClient do
   describe "VERSION" do
     subject(:version) { described_class::VERSION }
 
-    it { should eq("0.6.0") }
+    it { should eq("0.7.0") }
   end
 
   describe "#write" do


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/141!

This PR bumps the version to 0.7.0! :tada: 