### PR TITLE
Add FourByteFormatter helper to format 4-byte packets

### DIFF
--- a/lib/timex_datalink_client/helpers/four_byte_formatter.rb
+++ b/lib/timex_datalink_client/helpers/four_byte_formatter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class TimexDatalinkClient
+  class Helpers
+    module FourByteFormatter
+      BYTE_HEADERS = [0xc0, 0x30, 0x0c, 0x03, 0x00]
+      BYTE_NULL = 0x00
+      BYTE_TERMINATOR_MIDDLE = 0xfe
+      BYTE_TERMINATOR_END = 0xff
+
+      def four_byte_format_for(byte_arrays)
+        [].tap do |formatted_bytes|
+          byte_arrays.each_with_index do |byte_array, byte_array_index|
+            byte_array_remaining = byte_array.dup
+
+            loop do
+              byte_packet = byte_array_remaining.shift(4)
+              formatted_bytes << BYTE_HEADERS[byte_packet.count]
+
+              formatted_bytes.concat(byte_packet)
+
+              next if byte_packet.count == 4
+
+              has_next_line = byte_arrays[byte_array_index + 1]
+              terminator = has_next_line ? BYTE_TERMINATOR_MIDDLE : BYTE_TERMINATOR_END
+
+              formatted_bytes << terminator
+
+              null_pad = [BYTE_NULL] * (3 - byte_packet.count)
+              formatted_bytes.concat(null_pad)
+
+              break if byte_array_remaining.empty?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/helpers/char_encoders.rb",
     "lib/timex_datalink_client/helpers/cpacket_paginator.rb",
     "lib/timex_datalink_client/helpers/crc_packets_wrapper.rb",
+    "lib/timex_datalink_client/helpers/four_byte_formatter.rb",
     "lib/timex_datalink_client/helpers/length_packet_wrapper.rb",
 
     "lib/timex_datalink_client/protocol_1/alarm.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/161!

This PR adds `FourByteFormatter`, which provides `four_byte_format_for`.  This helps encode 4-byte packet-formatted data used throughout protocol 7.