### PR TITLE
Add packets class method to Eeprom::Activity

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom/activity.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/activity.rb
@@ -11,6 +11,39 @@ class TimexDatalinkClient
         METADATA_BYTES_BASE = 6
         METADATA_BYTES_SIZE = 5
 
+        PACKETS_TERMINATOR = 0x04
+
+        def self.packets(activities)
+          header(activities) + metadata_and_messages(activities) + [PACKETS_TERMINATOR]
+        end
+
+        def self.header(activities)
+          [
+            random_speech(activities),
+            0,
+            0,
+            0,
+            activities.count,
+            0
+          ]
+        end
+
+        def self.random_speech(activities)
+          activities.each_with_index.sum do |activity, activity_index|
+            activity.random_speech ? 1 << activity_index : 0
+          end
+        end
+
+        def self.metadata_and_messages(activities)
+          metadata = activities.each_with_index.map do |activity, activity_index|
+            activity.metadata_packet(activities.count + activity_index)
+          end
+
+          messages = activities.map { |activity| activity.messages_packet }
+
+          (metadata + messages).flatten
+        end
+
         attr_accessor :time, :messages, :random_speech
 
         # Create an Activity instance.

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/activity_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/activity_spec.rb
@@ -7,7 +7,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
   let(:messages) { [[0xb1]] }
   let(:random_speech) { false }
 
-  let(:activity_instance) do
+  let(:activity) do
     described_class.new(
       time: time,
       messages: messages,
@@ -16,7 +16,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
   end
 
   describe ".packets" do
-    let(:activities) { [activity_instance] }
+    let(:activities) { [activity] }
 
     subject(:packets) { described_class.packets(activities) }
 
@@ -25,7 +25,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
     end
 
     context "with two activities" do
-      let(:activity_instance_2) do
+      let(:activity_2) do
         described_class.new(
           time: Time.new(0, 1, 1, 2, 30, 0),
           messages: messages,
@@ -33,7 +33,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
         )
       end
 
-      let(:activities) { [activity_instance, activity_instance_2] }
+      let(:activities) { [activity, activity_2] }
 
       it do
         should eq [
@@ -47,7 +47,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
   describe "#metadata_packet" do
     let(:activity_index) { 1 }
 
-    subject(:metadata_packet) { activity_instance.metadata_packet(activity_index) }
+    subject(:metadata_packet) { activity.metadata_packet(activity_index) }
 
     it { should eq([0x01, 0x1e, 0x01, 0x0b, 0x00]) }
 
@@ -71,7 +71,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
   end
 
   describe "#messages_packet" do
-    subject(:messages_packet) { activity_instance.messages_packet }
+    subject(:messages_packet) { activity.messages_packet }
 
     it { should eq([0x30, 0xb1, 0xff, 0x00, 0x00]) }
 
@@ -118,7 +118,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
   end
 
   describe "#random_speech" do
-    subject(:random_speech_value) { activity_instance.random_speech }
+    subject(:random_speech_value) { activity.random_speech }
 
     it { should be_falsey }
 

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/activity_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/activity_spec.rb
@@ -15,6 +15,35 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Activity do
     )
   end
 
+  describe ".packets" do
+    let(:activities) { [activity_instance] }
+
+    subject(:packets) { described_class.packets(activities) }
+
+    it do
+      should eq([0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x1e, 0x01, 0x0b, 0x00, 0x30, 0xb1, 0xff, 0x00, 0x00, 0x04])
+    end
+
+    context "with two activities" do
+      let(:activity_instance_2) do
+        described_class.new(
+          time: Time.new(0, 1, 1, 2, 30, 0),
+          messages: messages,
+          random_speech: true
+        )
+      end
+
+      let(:activities) { [activity_instance, activity_instance_2] }
+
+      it do
+        should eq [
+          0x02, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x1e, 0x01, 0x10, 0x00, 0x02, 0x1e, 0x01, 0x15, 0x00, 0x30, 0xb1,
+          0xff, 0x00, 0x00, 0x30, 0xb1, 0xff, 0x00, 0x00, 0x04
+        ]
+      end
+    end
+  end
+
   describe "#metadata_packet" do
     let(:activity_index) { 1 }
 


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/163!

This PR adds `Eeprom::Activity.packets` for protocol 7!  This allows the `Activity` class to hold the logic responsible for rendering all the packets for activities (called "Life Style Setup" in the e-BRAIN software).