### PR TITLE
Privatize some protocol 7 Eeprom::Activity class methods and add YARDoc

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom/activity.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/activity.rb
@@ -13,6 +13,10 @@ class TimexDatalinkClient
 
         PACKETS_TERMINATOR = 0x04
 
+        # Compile data for all activities.
+        #
+        # @param activities [Array<Activity>] Activities to compile data for.
+        # @return [Array] Compiled data of all activities.
         def self.packets(activities)
           header(activities) + metadata_and_messages(activities) + [PACKETS_TERMINATOR]
         end

--- a/lib/timex_datalink_client/protocol_7/eeprom/activity.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/activity.rb
@@ -17,7 +17,7 @@ class TimexDatalinkClient
           header(activities) + metadata_and_messages(activities) + [PACKETS_TERMINATOR]
         end
 
-        def self.header(activities)
+        private_class_method def self.header(activities)
           [
             random_speech(activities),
             0,
@@ -28,13 +28,13 @@ class TimexDatalinkClient
           ]
         end
 
-        def self.random_speech(activities)
+        private_class_method def self.random_speech(activities)
           activities.each_with_index.sum do |activity, activity_index|
             activity.random_speech ? 1 << activity_index : 0
           end
         end
 
-        def self.metadata_and_messages(activities)
+        private_class_method def self.metadata_and_messages(activities)
           metadata = activities.each_with_index.map do |activity, activity_index|
             activity.metadata_packet(activities.count + activity_index)
           end


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/167!

This PR privatizes a few class methods on `Eeprom::Activity`, and adds YARDoc to the remaining public class method.