### PR TITLE
Add Protocol7::Eeprom::PhoneNumber

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -45,6 +45,7 @@ require "timex_datalink_client/protocol_4/wrist_app"
 
 require "timex_datalink_client/protocol_7/eeprom"
 require "timex_datalink_client/protocol_7/eeprom/activity"
+require "timex_datalink_client/protocol_7/eeprom/phone_number"
 require "timex_datalink_client/protocol_7/end"
 require "timex_datalink_client/protocol_7/start"
 require "timex_datalink_client/protocol_7/sync"

--- a/lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/four_byte_formatter"
+
+class TimexDatalinkClient
+  class Protocol7
+    class Eeprom
+      class PhoneNumber
+        include Helpers::FourByteFormatter
+
+        PHONE_NUMBER_DIGITS_MAP = {
+          "0" => 0x01,
+          "1" => 0x02,
+          "2" => 0x03,
+          "3" => 0x04,
+          "4" => 0x05,
+          "5" => 0x06,
+          "6" => 0x07,
+          "7" => 0x08,
+          "8" => 0x09,
+          "9" => 0x0a
+        }.freeze
+
+        PACKETS_TERMINATOR = 0x03
+
+        # Compile data for all phone numbers.
+        #
+        # @param phone_numbers [Array<PhoneNumber>] Phone numbers to compile data for.
+        # @return [Array] Compiled data of all phone numbers.
+        def self.packets(phone_numbers)
+          header(phone_numbers) + names_and_numbers(phone_numbers) + [PACKETS_TERMINATOR]
+        end
+
+        private_class_method def self.header(phone_numbers)
+          [
+            phone_numbers.count,
+            0
+          ]
+        end
+
+        private_class_method def self.names_and_numbers(phone_numbers)
+          names_and_numbers = phone_numbers.flat_map(&:name_and_number)
+
+          phone_numbers.first.four_byte_format_for(names_and_numbers)
+        end
+
+        attr_accessor :name, :number
+
+        # Create a PhoneNumber instance.
+        #
+        # @param name [Array<Integer>] Name associated to phone number.
+        # @param number [String] Phone number text.
+        # @return [PhoneNumber] PhoneNumber instance.
+        def initialize(name: [], number:)
+          @name = name
+          @number = number
+        end
+
+        # Compile an unformatted name and phone number.
+        #
+        # @return [Array<Integer>] Array of integers that represent bytes.
+        def name_and_number
+          [
+            name,
+            number_characters
+          ]
+        end
+
+        private
+
+        def number_characters
+          number.each_char.map { |digit| PHONE_NUMBER_DIGITS_MAP[digit] }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/phone_number_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/phone_number_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber do
+  let(:name) { [0xb1] }
+  let(:number) { "0" }
+
+  let(:phone_number) do
+    described_class.new(
+      name: name,
+      number: number
+    )
+  end
+
+  describe ".packets" do
+    let(:phone_numbers) { [phone_number] }
+
+    subject(:packets) { described_class.packets(phone_numbers) }
+
+    it { should eq([0x01, 0x00, 0x30, 0xb1, 0xfe, 0x00, 0x00, 0x30, 0x01, 0xff, 0x00, 0x00, 0x03]) }
+
+    context "with two phone numbers" do
+      let(:phone_number_2) do
+        described_class.new(
+          name: [0xb1, 0xb2, 0xb3],
+          number: "1234567890"
+        )
+      end
+
+      let(:phone_numbers) { [phone_number, phone_number_2] }
+
+      it do
+        should eq [
+          0x02, 0x00, 0x30, 0xb1, 0xfe, 0x00, 0x00, 0x30, 0x01, 0xfe, 0x00, 0x00, 0x03, 0xb1, 0xb2, 0xb3, 0xfe, 0x00,
+          0x02, 0x03, 0x04, 0x05, 0x00, 0x06, 0x07, 0x08, 0x09, 0x0c, 0x0a, 0x01, 0xff, 0x00, 0x03
+        ]
+      end
+    end
+  end
+
+  describe "#name_and_number" do
+    subject(:name_and_number) { phone_number.name_and_number }
+
+    it { should eq([[177], [1]]) }
+
+    context "when name is [0xb1, 0xb2, 0xb3]" do
+      let(:name) { [0xb1, 0xb2, 0xb3] }
+
+      it { should eq([[177, 178, 179], [1]]) }
+    end
+
+    context "when number is \"1234567890\"" do
+      let(:number) { "1234567890" }
+
+      it { should eq([[177], [2, 3, 4, 5, 6, 7, 8, 9, 10, 1]]) }
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |s|
 
     "lib/timex_datalink_client/protocol_7/eeprom.rb",
     "lib/timex_datalink_client/protocol_7/eeprom/activity.rb",
+    "lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb",
     "lib/timex_datalink_client/protocol_7/end.rb",
     "lib/timex_datalink_client/protocol_7/start.rb",
     "lib/timex_datalink_client/protocol_7/sync.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/158! :tada: 

This PR adds `Protocol7::Eeprom::PhoneNumber` to transfer phone numbers to the DSI e-BRAIN!