### PR TITLE
Fix YARDoc type for Protocol7::Eeprom#initialize's phone_number

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom.rb
@@ -25,7 +25,7 @@ class TimexDatalinkClient
       # Create an Eeprom instance.
       #
       # @param activities [Array<Activity>, nil] Activities to be added to EEPROM data.
-      # @param phone_numbers [Array<Activity>, nil] Phone numbers to be added to EEPROM data.
+      # @param phone_numbers [Array<PhoneNumber>, nil] Phone numbers to be added to EEPROM data.
       # @return [Eeprom] Eeprom instance.
       def initialize(activities: nil, phone_numbers: nil)
         @activities = activities


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/172!

Quick PR to fix an incorrect type in a line of YARDoc.