### PR TITLE
Fix protocol 7 PhoneNumber.packets raising undefined method error with empty phone numbers

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb
@@ -39,6 +39,8 @@ class TimexDatalinkClient
         end
 
         private_class_method def self.names_and_numbers(phone_numbers)
+          return [] if phone_numbers.empty?
+
           names_and_numbers = phone_numbers.flat_map(&:name_and_number)
 
           phone_numbers.first.four_byte_format_for(names_and_numbers)

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/phone_number_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/phone_number_spec.rb
@@ -20,6 +20,12 @@ describe TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber do
 
     it { should eq([0x01, 0x00, 0x30, 0xb1, 0xfe, 0x00, 0x00, 0x30, 0x01, 0xff, 0x00, 0x00, 0x03]) }
 
+    context "with no phone numbers" do
+      let(:phone_numbers) { [] }
+
+      it { should eq([0x00, 0x00, 0x03]) }
+    end
+
     context "with two phone numbers" do
       let(:phone_number_2) do
         described_class.new(


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/174!

Quick fix to correctly handle protocol 7 sending empty phone numbers.  This provides 1:1 parity with the original software, which looks like this:

```
07 20 00 00 07 C2 FF
26 90 05 01 44 53 49 20 54 6F 79 73 20 70 72 65 73 65 6E 74 73 2E 2E 2E 65 42 72 61 69 6E 21 00 00 00 00 00 34 07
09 91 05 01 00 00 03 7C 08
05 92 05 62 BD
04 21 D8 C2
```