### PR TITLE
Fix protocol 7 Speech header for phrase lengths

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
@@ -164,7 +164,7 @@ class TimexDatalinkClient
         HEADER_VALUE_5_USER_MULTIPLIER = 5
 
         HEADER_VALUE_5_PHRASE = 2
-        HEADER_VALUE_5_PHRASE_INDEX = 5
+        HEADER_VALUE_5_PHRASE_PACKET = 5
 
         PACKETS_TERMINATOR = 0x05
 
@@ -260,7 +260,7 @@ class TimexDatalinkClient
             end
 
             value += HEADER_VALUE_5_PHRASE * phrases.count
-            value += HEADER_VALUE_5_PHRASE_INDEX * phrase_index
+            value += HEADER_VALUE_5_PHRASE_PACKET * phrases.first(phrase_index).sum { |phrase| 1 + phrase.length / 4 }
 
             value
           end


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/183.

This PR fixes an issue where phrase lengths are not considered in the protocol 7 Speech header.

A spec for this is not supplied because more exhaustive tests are coming in https://github.com/synthead/timex_datalink_client/pull/182.