### PR TITLE
Rename Protocol7::Eeprom::Games#packets to #packet

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom.rb
@@ -60,7 +60,7 @@ class TimexDatalinkClient
       def all_packets
         [].tap do |packets|
           packets.concat(Activity.packets(activities)) if activities
-          packets.concat(games.packets) if games
+          packets.concat(games.packet) if games
           packets.concat(PhoneNumber.packets(phone_numbers)) if phone_numbers
           packets.concat(speech.packets) if speech
         end

--- a/lib/timex_datalink_client/protocol_7/eeprom/games.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/games.rb
@@ -69,7 +69,7 @@ class TimexDatalinkClient
         # Compile data for games.
         #
         # @return [Array<Integer>] Compiled data for games.
-        def packets
+        def packet
           [
             enabled_games,
             countdown_timer_time,

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/games_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/games_spec.rb
@@ -35,8 +35,8 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Games do
     )
   end
 
-  describe "#packets" do
-    subject(:packets) { sounds.packets }
+  describe "#packet" do
+    subject(:packet) { sounds.packet }
 
     it { should eq([0x00, 0x00, 0x58, 0x02, 0x30, 0x62, 0xfe, 0x00, 0x00, 0x30, 0x62, 0xfe, 0x00, 0x00, 0x02]) }
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/186!

Renames `Protocol7::Eeprom::Games#packets` to `#packet`.