### PR TITLE
Rename Protocol7::Eeprom::Speech#packets to #packet

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom.rb
@@ -62,7 +62,7 @@ class TimexDatalinkClient
           packets.concat(Activity.packets(activities)) if activities
           packets.concat(games.packet) if games
           packets.concat(PhoneNumber.packets(phone_numbers)) if phone_numbers
-          packets.concat(speech.packets) if speech
+          packets.concat(speech.packet) if speech
         end
       end
     end

--- a/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
@@ -114,7 +114,7 @@ class TimexDatalinkClient
         # Compile data for nicknames and phrases.
         #
         # @return [Array<Integer>] Compiled data of all nicknames and phrases.
-        def packets
+        def packet
           header + nickname_bytes + formatted_phrases + [PACKETS_TERMINATOR]
         end
 

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/speech_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/speech_spec.rb
@@ -15,8 +15,8 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Speech do
     )
   end
 
-  describe "#packets" do
-    subject(:packets) { speech.packets }
+  describe "#packet" do
+    subject(:packet) { speech.packet }
 
     it do
       should eq [


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/187!

Renames `Protocol7::Eeprom::Speech#packets` to `#packet`.