### PR TITLE
Add Protocol7::PhraseBuilder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     timex_datalink_client (0.7.0)
       crc (~> 0.4.2)
+      mdb (~> 0.5.0)
       rubyserial (~> 0.6.0)
 
 GEM
@@ -13,6 +14,7 @@ GEM
     crc (0.4.2)
     diff-lcs (1.5.0)
     ffi (1.15.5)
+    mdb (0.5.0)
     rainbow (3.1.1)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)

--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -51,6 +51,7 @@ require "timex_datalink_client/protocol_7/eeprom/games"
 require "timex_datalink_client/protocol_7/eeprom/phone_number"
 require "timex_datalink_client/protocol_7/eeprom/speech"
 require "timex_datalink_client/protocol_7/end"
+require "timex_datalink_client/protocol_7/phrase_builder"
 require "timex_datalink_client/protocol_7/start"
 require "timex_datalink_client/protocol_7/sync"
 

--- a/lib/timex_datalink_client/protocol_7/phrase_builder.rb
+++ b/lib/timex_datalink_client/protocol_7/phrase_builder.rb
@@ -59,7 +59,7 @@ class TimexDatalinkClient
       def vocab_links_for_vocab(vocab)
         links = vocab_links_table.select { |vocab_link| vocab_link[:"PC Index"] == vocab[:"PC Index"] }
 
-        links.sort_by { |link| link[:Sequence] }
+        links.sort_by { |link| link[:Sequence].to_i }
       end
 
       def vocab_for_vocab_link(vocab_link)

--- a/lib/timex_datalink_client/protocol_7/phrase_builder.rb
+++ b/lib/timex_datalink_client/protocol_7/phrase_builder.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "mdb"
+
+class TimexDatalinkClient
+  class Protocol7
+    class PhraseBuilder
+      class WordNotFound < StandardError; end
+
+      attr_accessor :database
+
+      # Create a PhraseBuilder instance.
+      #
+      # @param database [String] Database file to compile phrase data from.
+      # @return [PhraseBuilder] PhraseBuilder instance.
+      def initialize(database:)
+        @database = database
+      end
+
+      # Compile vocabulary IDs for protocol 7 phrases.
+      #
+      # @param words [Array<String>] Array of words.
+      # @raise [WordNotFound] Word not found in protocol 7 database.
+      # @return [Array<Integer>] Array of protocol 7 vocabulary IDs.
+      def vocab_ids_for(*words)
+        words.flat_map do |word|
+          vocab = vocab_for_word(word)
+
+          raise(WordNotFound, "#{word} is not a valid word!") unless vocab
+
+          vocab_links = vocab_links_for_vocab(vocab)
+
+          vocab_links.map do |vocab_link|
+            linked_vocab = vocab_for_vocab_link(vocab_link)
+
+            linked_vocab[:"PC Index"].to_i
+          end
+        end
+      end
+
+      private
+
+      def mdb
+        @mdb ||= Mdb.open(database)
+      end
+
+      def vocab_table
+        @vocab_table ||= mdb["Vocab"]
+      end
+
+      def vocab_links_table
+        @vocab_links_table ||= mdb["Vocab Links"]
+      end
+
+      def vocab_for_word(word)
+        vocab_table.detect { |vocab| vocab[:Label].casecmp?(word) }
+      end
+
+      def vocab_links_for_vocab(vocab)
+        links = vocab_links_table.select { |vocab_link| vocab_link[:"PC Index"] == vocab[:"PC Index"] }
+
+        links.sort_by { |link| link[:Sequence] }
+      end
+
+      def vocab_for_vocab_link(vocab_link)
+        vocab_table.detect { |vocab| vocab[:"PC Index"] == vocab_link[:"eBrain Index"] }
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_7/phrase_builder_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/phrase_builder_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol7::PhraseBuilder do
+  let(:phrase_builder) { described_class.new(database: "") }
+
+  let(:vocab_results) do
+    [
+      { :"PC Index" => "292", :Label => "Cool" },
+      { :"PC Index" => "1021", :Label => "<NoPause>" },
+      { :"PC Index" => "74", :Label => "'est" },
+      { :"PC Index" => "1233", :Label => "Coolest" },
+      { :"PC Index" => "285", :Label => "Club" }
+    ]
+  end
+
+  let(:vocab_links_results) do
+    [
+      { :"PC Index" => "292", :Sequence => "1", :"eBrain Index" => "292" },
+      { :"PC Index" => "285", :Sequence => "1", :"eBrain Index" => "285" },
+      { :"PC Index" => "1233", :Sequence => "1", :"eBrain Index" => "292" },
+      { :"PC Index" => "1233", :Sequence => "2", :"eBrain Index" => "1021" },
+      { :"PC Index" => "1233", :Sequence => "3", :"eBrain Index" => "74" }
+    ]
+  end
+
+  let(:mdb_double) do
+    double(:Mdb).tap do |mdb|
+      allow(mdb).to receive(:[]).with("Vocab").and_return(vocab_results)
+      allow(mdb).to receive(:[]).with("Vocab Links").and_return(vocab_links_results)
+    end
+  end
+
+  before(:each) { allow(phrase_builder).to receive(:mdb).and_return(mdb_double) }
+
+  describe "#vocab_ids_for" do
+    subject(:vocab_ids_for) { phrase_builder.vocab_ids_for(*words) }
+
+    context "when words is [\"cool\", \"club\"]" do
+      let(:words) { ["cool", "club"] }
+
+      it { should eq([0x124, 0x11d]) }
+    end
+
+    context "when words is [\"coolest\", \"club\"]" do
+      let(:words) { ["coolest", "club"] }
+
+      it { should eq([0x124, 0x3fd, 0x4a, 0x11d]) }
+    end
+
+    context "when words is [\"nostalgia\", \"club\"]" do
+      let(:words) { ["nostalgia", "club"] }
+
+      it { expect { vocab_ids_for }.to raise_error(described_class::WordNotFound, "nostalgia is not a valid word!") }
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -70,6 +70,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb",
     "lib/timex_datalink_client/protocol_7/eeprom/speech.rb",
     "lib/timex_datalink_client/protocol_7/end.rb",
+    "lib/timex_datalink_client/protocol_7/phrase_builder.rb",
     "lib/timex_datalink_client/protocol_7/start.rb",
     "lib/timex_datalink_client/protocol_7/sync.rb",
 

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -88,6 +88,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "crc", "~> 0.4.2"
   s.add_dependency "rubyserial", "~> 0.6.0"
+  s.add_dependency "mdb", "~> 0.5.0"
 
   s.add_development_dependency "rspec", "~> 3.11.0"
   s.add_development_dependency "tzinfo", "~> 2.0.5"


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/193!

This PR adds a little class to read the original `pcvocab.mdb` file from the eBrain software to turn words into vocabulary IDs.  These IDs are used throughout protocol 7.