### PR TITLE
Use three-digit hex values for phone numbers in Protocol7::PhoneNumber

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/phone_number.rb
@@ -9,16 +9,16 @@ class TimexDatalinkClient
         include Helpers::FourByteFormatter
 
         PHONE_NUMBER_DIGITS_MAP = {
-          "0" => 0x01,
-          "1" => 0x02,
-          "2" => 0x03,
-          "3" => 0x04,
-          "4" => 0x05,
-          "5" => 0x06,
-          "6" => 0x07,
-          "7" => 0x08,
-          "8" => 0x09,
-          "9" => 0x0a
+          "0" => 0x001,
+          "1" => 0x002,
+          "2" => 0x003,
+          "3" => 0x004,
+          "4" => 0x005,
+          "5" => 0x006,
+          "6" => 0x007,
+          "7" => 0x008,
+          "8" => 0x009,
+          "9" => 0x00a
         }.freeze
 
         PACKETS_TERMINATOR = 0x03


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/199!

Addresses a nit where phone number values in the `PHONE_NUMBER_DIGITS_MAP` map were two digits, not three.  Three digit hex values for speech are used everywhere else in protocol 7 because the speech data is 10-bit.