### PR TITLE
Fix inconsistent code example for activity in protocol 7 documentation

### DIFF
--- a/docs/dsi_ebrain_protocol_7.md
+++ b/docs/dsi_ebrain_protocol_7.md
@@ -41,7 +41,7 @@ activities = [
     random_speech: false
   ),
   TimexDatalinkClient::Protocol7::Eeprom::Activity.new(
-    time: Time.new(0, 1, 1, 0, 30, 0),  # Year, month, and day is ignored.
+    time: Time.new(0, 1, 1, 8, 0, 0),  # Year, month, and day is ignored.
     messages: [picture_day],
     random_speech: true
   )


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/202.

Uses `Time.new(0, 1, 1, 8, 0, 0)` to match 8 AM "Picture Day" example in the protocol 7 documentation.