### PR TITLE
 Use consistent activity example times in protocol 7 documentation

### DIFF
--- a/docs/dsi_ebrain_protocol_7.md
+++ b/docs/dsi_ebrain_protocol_7.md
@@ -188,7 +188,7 @@ activities = [
     random_speech: false
   ),
   TimexDatalinkClient::Protocol7::Eeprom::Activity.new(
-    time: Time.new(0, 1, 1, 0, 30, 0),  # Year, month, and day is ignored.
+    time: Time.new(0, 1, 1, 8, 0, 0),  # Year, month, and day is ignored.
     messages: [picture_day],
     random_speech: true
   )


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/204.

Uses 8 AM in second activity item examples in the protocol 7 documentation.  This makes the individual code example match the complete code example.