### PR TITLE
Add documentation for acquiring SPC and ZAP files

### DIFF
--- a/docs/acquiring_spc_and_zap_files.md
+++ b/docs/acquiring_spc_and_zap_files.md
@@ -1,0 +1,66 @@
+# Acquiring SPC and ZAP files for protocols 3 and 4
+
+SPC files are sound themes, and ZAP files are WristApp programs.  Sound themes and WristApp programs are supported in
+protocols 3 and 4, namely the Timex Datalink 150 and 150s.  These files can be transferred using the `SoundTheme` and
+`WristApp` models described in the [protocol 3](docs/timex_datalink_protocol_3.md) and
+[protocol 4](docs/timex_datalink_protocol_4.md) documentation.
+
+## Extracting SPC and ZAP files from the Timex Datalink software
+
+First, we want to acquire the last version of the Timex Datalink software, which is version 2.1d.  This can be
+downloaded from [Timex's website](https://assets.timex.com/html/data_link_software.html) (here's a
+[direct link](https://assets.timex.com/downloads/TDL21D.EXE)).
+
+With the software downloaded, follow the directions below to extract SPC and ZAP files from the installer.
+
+### From UNIX-compatible systems with bsdtar
+
+These instructions will use bsdtar, which is a part of [libarchive](https://www.libarchive.org), so make sure this is
+installed first.  libarchive is probably a package in your distro's package manager, so install it this way, if
+possible.
+
+Then, extract `SETUP.EXE` from `TDL21D.EXE` like so:
+
+```
+bsdtar xvf TDL21D.EXE SETUP.EXE
+```
+
+From here, we can extract the sound themes from `SETUP.EXE` like this:
+
+```
+mkdir sound-themes
+bsdtar xvf SETUP.EXE -C sound-themes *.SPC
+```
+
+And we can extract the WristApps from `SETUP.EXE` like this:
+
+```
+mkdir wrist-apps
+bsdtar xvf SETUP.EXE -C wrist-apps *.ZAP
+```
+
+### From Windows with 7zip
+
+These instructions will use [7zip](https://www.7-zip.org), so make sure this is installed first.
+
+Right-click on `TDL21D.EXE`, hover over 7zip, and click on Open archive:
+
+![image](https://user-images.githubusercontent.com/820984/209208705-169a793d-c977-4dbc-8f26-1f85401e086d.png)
+
+In the 7zip browser, you'll see `SETUP.EXE`.  Right-click on this file, and click on Open Inside:
+
+![image](https://user-images.githubusercontent.com/820984/209208792-c925a6ec-6e95-4ef9-9c46-8c758ace8e89.png)
+
+Then, we can extract the sound themes by selecting the SPC files, right-clicking on the selection, and clicking Copy
+To...
+
+A window will appear that will ask you where you want to extract the sound themes.  Pick a location, then click OK.
+
+![image](https://user-images.githubusercontent.com/820984/209209056-cddc237f-a757-48c5-9a5b-b6f328984f33.png)
+
+The WristApps can also be extracted by selecting the ZAP files, right-clicking on the selection, and clicking Copy
+To...
+
+A window will appear that will ask you where you want to extract the WristApps.  Pick a location, then click OK.
+
+![image](https://user-images.githubusercontent.com/820984/209209169-a7269cfe-d213-4a50-a671-3bb49f01325a.png)

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -157,6 +157,10 @@ TimexDatalinkClient::Protocol3::Alarm.new(
 
 ![image](https://user-images.githubusercontent.com/820984/190347561-eab2353d-90d0-44b5-aa69-eb58c4e1c4d4.png)
 
+This example requires a ZAP file present to upload.  See the
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](docs/acquiring_spc_and_zap_files.md) for information
+on how to acquire ZAP files from the original Timex Datalink software.
+
 ```ruby
 TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP")
 ```
@@ -164,6 +168,10 @@ TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP
 ## Watch Sounds
 
 ![image](https://user-images.githubusercontent.com/820984/190347710-b57fe25b-95b1-49b6-a897-6ad6f2ffe1aa.png)
+
+This example requires a SPC file present to upload.  See the
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](docs/acquiring_spc_and_zap_files.md) for information
+on how to acquire SPC files from the original Timex Datalink software.
 
 ```ruby
 TimexDatalinkClient::Protocol3::SoundTheme.new(spc_file: "DATALINK/SND/DEFAULT.SPC")
@@ -175,6 +183,10 @@ TimexDatalinkClient::Protocol3::SoundOptions.new(
 ```
 
 ## Complete code example
+
+This example requires SPC and ZAP files present to upload.  See the
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](docs/acquiring_spc_and_zap_files.md) for information
+on how to acquire SPC and ZAP files from the original Timex Datalink software.
 
 Here is an example that syncs all models to a device that supports protocol 3:
 

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -158,7 +158,7 @@ TimexDatalinkClient::Protocol3::Alarm.new(
 ![image](https://user-images.githubusercontent.com/820984/190347561-eab2353d-90d0-44b5-aa69-eb58c4e1c4d4.png)
 
 This example requires a ZAP file present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](docs/acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire ZAP files from the original Timex Datalink software.
 
 ```ruby
@@ -170,7 +170,7 @@ TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP
 ![image](https://user-images.githubusercontent.com/820984/190347710-b57fe25b-95b1-49b6-a897-6ad6f2ffe1aa.png)
 
 This example requires a SPC file present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](docs/acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire SPC files from the original Timex Datalink software.
 
 ```ruby
@@ -185,7 +185,7 @@ TimexDatalinkClient::Protocol3::SoundOptions.new(
 ## Complete code example
 
 This example requires SPC and ZAP files present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](docs/acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire SPC and ZAP files from the original Timex Datalink software.
 
 Here is an example that syncs all models to a device that supports protocol 3:

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -162,7 +162,7 @@ This example requires a ZAP file present to upload.  See the
 on how to acquire ZAP files from the original Timex Datalink software.
 
 ```ruby
-TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP")
+TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "TIMER13.ZAP")
 ```
 
 ## Watch Sounds
@@ -174,7 +174,7 @@ This example requires a SPC file present to upload.  See the
 on how to acquire SPC files from the original Timex Datalink software.
 
 ```ruby
-TimexDatalinkClient::Protocol3::SoundTheme.new(spc_file: "DATALINK/SND/DEFAULT.SPC")
+TimexDatalinkClient::Protocol3::SoundTheme.new(spc_file: "DEFAULT.SPC")
 
 TimexDatalinkClient::Protocol3::SoundOptions.new(
   hourly_chime: true,
@@ -302,14 +302,14 @@ models = [
     appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
   ),
 
-  TimexDatalinkClient::Protocol3::SoundTheme.new(spc_file: "DATALINK/SND/DEFHIGH.SPC"),
+  TimexDatalinkClient::Protocol3::SoundTheme.new(spc_file: "DEFHIGH.SPC"),
 
   TimexDatalinkClient::Protocol3::SoundOptions.new(
     hourly_chime: true,
     button_beep: true
   ),
 
-  TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP"),
+  TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "TIMER13.ZAP"),
 
   TimexDatalinkClient::Protocol3::End.new
 ]

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -157,6 +157,10 @@ TimexDatalinkClient::Protocol4::Alarm.new(
 
 ![image](https://user-images.githubusercontent.com/820984/190347561-eab2353d-90d0-44b5-aa69-eb58c4e1c4d4.png)
 
+This example requires a ZAP file present to upload.  See the
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+on how to acquire ZAP files from the original Timex Datalink software.
+
 ```ruby
 TimexDatalinkClient::Protocol4::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP")
 ```
@@ -164,6 +168,10 @@ TimexDatalinkClient::Protocol4::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP
 ## Watch Sounds
 
 ![image](https://user-images.githubusercontent.com/820984/190347710-b57fe25b-95b1-49b6-a897-6ad6f2ffe1aa.png)
+
+This example requires a SPC file present to upload.  See the
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+on how to acquire SPC files from the original Timex Datalink software.
 
 ```ruby
 TimexDatalinkClient::Protocol4::SoundTheme.new(spc_file: "DATALINK/SND/DEFAULT.SPC")
@@ -175,6 +183,10 @@ TimexDatalinkClient::Protocol4::SoundOptions.new(
 ```
 
 ## Complete code example
+
+This example requires SPC and ZAP files present to upload.  See the
+[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+on how to acquire SPC and ZAP files from the original Timex Datalink software.
 
 Here is an example that syncs all models to a device that supports protocol 4:
 

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -162,7 +162,7 @@ This example requires a ZAP file present to upload.  See the
 on how to acquire ZAP files from the original Timex Datalink software.
 
 ```ruby
-TimexDatalinkClient::Protocol4::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP")
+TimexDatalinkClient::Protocol4::WristApp.new(zap_file: "TIMER13.ZAP")
 ```
 
 ## Watch Sounds
@@ -174,7 +174,7 @@ This example requires a SPC file present to upload.  See the
 on how to acquire SPC files from the original Timex Datalink software.
 
 ```ruby
-TimexDatalinkClient::Protocol4::SoundTheme.new(spc_file: "DATALINK/SND/DEFAULT.SPC")
+TimexDatalinkClient::Protocol4::SoundTheme.new(spc_file: "DEFAULT.SPC")
 
 TimexDatalinkClient::Protocol4::SoundOptions.new(
   hourly_chime: true,
@@ -302,14 +302,14 @@ models = [
     appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
   ),
 
-  TimexDatalinkClient::Protocol4::SoundTheme.new(spc_file: "DATALINK/SND/DEFHIGH.SPC"),
+  TimexDatalinkClient::Protocol4::SoundTheme.new(spc_file: "DEFHIGH.SPC"),
 
   TimexDatalinkClient::Protocol4::SoundOptions.new(
     hourly_chime: true,
     button_beep: true
   ),
 
-  TimexDatalinkClient::Protocol4::WristApp.new(zap_file: "DATALINK/APP/TIMER13.ZAP"),
+  TimexDatalinkClient::Protocol4::WristApp.new(zap_file: "TIMER13.ZAP"),
 
   TimexDatalinkClient::Protocol4::End.new
 ]


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/178!

This PR adds some documentation around acquiring SPC and ZAP files by extracting them from the original Timex Datalink software :sparkles: 