### PR TITLE
Add documentation on how to acquire pcvocab.mdb for protocol 7

### DIFF
--- a/docs/acquiring_pcvocab.mdb.md
+++ b/docs/acquiring_pcvocab.mdb.md
@@ -7,8 +7,8 @@ database file, `pcvocab.mdb`.
 
 ## Extracting pcvocab.mdb from the DSI e-BRAIN software CD
 
-The pcvocab.mdb file is buried inside of installer files on the DSI e-BRAIN software CD.  First, acquire an ISO image of
-the DSI e-BRAIN CD.  If you need to download it, you can find it on
+The `pcvocab.mdb` file is buried inside of installer files on the DSI e-BRAIN software CD.  First, acquire an ISO image
+of the DSI e-BRAIN CD.  If you need to download it, you can find it on
 [the Internet Archive](https://archive.org/details/ebrain-1.1.6) (here's a
 [direct link](https://archive.org/download/ebrain-1.1.6/ebrain-1.1.6.iso)).
 

--- a/docs/acquiring_pcvocab.mdb.md
+++ b/docs/acquiring_pcvocab.mdb.md
@@ -1,0 +1,56 @@
+# Acquiring pcvocab.mdb for Protocol 7
+
+Protocol 7 focuses heavily on speech phrases, and the phrases are built using arrays of 10-bit codes that represent
+speech data.  The arrays of codes can be built from English words using `TimexDatalinkClient::Protocol7::PhraseBuilder`,
+as seen in [the protocol 7 documentation](dsi_ebrain_protocol_7.md).  This class requires the original DSI e-BRAIN
+database file, `pcvocab.mdb`.
+
+## Extracting pcvocab.mdb from the DSI e-BRAIN software CD
+
+The pcvocab.mdb file is buried inside of installer files on the DSI e-BRAIN software CD.  First, acquire an ISO image of
+the DSI e-BRAIN CD.  If you need to download it, you can find it on
+[the Internet Archive](https://archive.org/details/ebrain-1.1.6) (here's a
+[direct link](https://archive.org/download/ebrain-1.1.6/ebrain-1.1.6.iso)).
+
+With the ISO downloaded, follow the directions below to extract pcvocab.mdb from the image.
+
+### From UNIX-compatible systems with 7z
+
+These instructions will use 7z, which is a part of [p7zip](https://p7zip.sourceforge.net), so make sure this is
+installed first.  p7zip is probably a package in your distro's package manager, so install it this way, if
+possible.
+
+`pcvocab.mdb` is called `pcvocab.mdb1` in the `Cabs.w4.cab` archive, which is inside of `eBrain.MSI` on the ISO.  We
+need to perform a few extractions, then rename the database file, like so:
+
+```
+7z e ebrain-1.1.6.iso eBrain.MSI
+7z e eBrain.MSI Cabs.w4.cab
+7z e Cabs.w4.cab pcvocab.mdb1
+
+mv pcvocab.mdb1 pcvocab.mdb
+```
+
+### From Windows with 7zip
+
+These instructions will use [7zip](https://www.7-zip.org), so make sure this is installed first.
+
+Right-click on `ebrain-1.1.6.iso`, hover over 7zip, and click on Open archive:
+
+![image](https://user-images.githubusercontent.com/820984/209248423-fbf19df8-0854-4db0-852d-8c70b3b35741.png)
+
+In the 7zip browser, you'll see `eBrain.MSI`.  Right-click on this file, and click on Open Inside:
+
+![image](https://user-images.githubusercontent.com/820984/209248532-b9b883b5-e53b-4109-8267-d2d55882084f.png)
+
+In `eBrain.MSI`, find `Cabs.w4.cab`.  Right-click on this file, and click on Open Inside:
+
+![image](https://user-images.githubusercontent.com/820984/209248587-cdbb09ba-f978-4497-add4-b9fe68c43cec.png)
+
+Then, right-click `pcvocab.mdb1` and click Copy To...
+
+A window will appear that will ask you where you want to extract the file.  Pick a location, then click OK.
+
+![image](https://user-images.githubusercontent.com/820984/209248681-429705d7-b74d-4323-8f53-de3d67f71ac2.png)
+
+After the file has been extracted, rename it to `pcvocab.mdb`.

--- a/docs/acquiring_spc_and_zap_files.md
+++ b/docs/acquiring_spc_and_zap_files.md
@@ -13,30 +13,20 @@ downloaded from [Timex's website](https://assets.timex.com/html/data_link_softwa
 
 With the software downloaded, follow the directions below to extract SPC and ZAP files from the installer.
 
-### From UNIX-compatible systems with bsdtar
+### From UNIX-compatible systems with 7z
 
-These instructions will use bsdtar, which is a part of [libarchive](https://www.libarchive.org), so make sure this is
-installed first.  libarchive is probably a package in your distro's package manager, so install it this way, if
+These instructions will use 7z, which is a part of [p7zip](https://p7zip.sourceforge.net), so make sure this is
+installed first.  p7zip is probably a package in your distro's package manager, so install it this way, if
 possible.
 
-Then, extract `SETUP.EXE` from `TDL21D.EXE` like so:
+The SPC and ZAP files are in the `SETUP.EXE` file, which is inside of `TDL21D.EXE`.  These commands will extract
+`SETUP.EXE` from `TDL21D.EXE`, create `sound-themes` and `wrist-apps` directories, and extract the SPC and ZAP files to
+the appropriate directories.
 
 ```
-bsdtar xvf TDL21D.EXE SETUP.EXE
-```
-
-From here, we can extract the sound themes from `SETUP.EXE` like this:
-
-```
-mkdir sound-themes
-bsdtar xvf SETUP.EXE -C sound-themes *.SPC
-```
-
-And we can extract the WristApps from `SETUP.EXE` like this:
-
-```
-mkdir wrist-apps
-bsdtar xvf SETUP.EXE -C wrist-apps *.ZAP
+7z e TDL21D.EXE SETUP.EXE
+7z e SETUP.EXE -osound-themes *.SPC
+7z e SETUP.EXE -owrist-apps *.ZAP
 ```
 
 ### From Windows with 7zip

--- a/docs/dsi_ebrain_protocol_7.md
+++ b/docs/dsi_ebrain_protocol_7.md
@@ -5,6 +5,10 @@ software version 1.1.6.
 
 ![image](https://user-images.githubusercontent.com/820984/207302212-543abafa-2c6b-4cc7-a413-31f3d8567268.png)
 
+Every code example below uses the `pcvocab.mdb` speech database file.  Please see the
+[Acquiring pcvocab.mdb for Protocol 7 documentation](acquiring_pcvocab.mdb.md) for how to acquire `pcvocab.mdb` for
+these examples.
+
 ## Nicknames
 
 ![image](https://user-images.githubusercontent.com/820984/207304059-cdb2bc30-19c3-4556-aaec-f2b20df3f58c.png)


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/216!

This PR adds documentation on how to acquire `pcvocab.mdb`, which is used with`TimexDatalinkClient::Protocol7::PhraseBuilder` to build speech phrase arrays for most models in protocol 7.