### PR TITLE
Fix capitalization for title in "acquiring SPC and ZAP files" documentation

### DIFF
--- a/docs/acquiring_spc_and_zap_files.md
+++ b/docs/acquiring_spc_and_zap_files.md
@@ -1,4 +1,4 @@
-# Acquiring SPC and ZAP files for protocols 3 and 4
+# Acquiring SPC and ZAP Files for Protocols 3 and 4
 
 SPC files are sound themes, and ZAP files are WristApp programs.  Sound themes and WristApp programs are supported in
 protocols 3 and 4, namely the Timex Datalink 150 and 150s.  These files can be transferred using the `SoundTheme` and

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -158,7 +158,7 @@ TimexDatalinkClient::Protocol3::Alarm.new(
 ![image](https://user-images.githubusercontent.com/820984/190347561-eab2353d-90d0-44b5-aa69-eb58c4e1c4d4.png)
 
 This example requires a ZAP file present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP Files for Protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire ZAP files from the original Timex Datalink software.
 
 ```ruby
@@ -170,7 +170,7 @@ TimexDatalinkClient::Protocol3::WristApp.new(zap_file: "TIMER13.ZAP")
 ![image](https://user-images.githubusercontent.com/820984/190347710-b57fe25b-95b1-49b6-a897-6ad6f2ffe1aa.png)
 
 This example requires a SPC file present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP Files for Protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire SPC files from the original Timex Datalink software.
 
 ```ruby
@@ -185,7 +185,7 @@ TimexDatalinkClient::Protocol3::SoundOptions.new(
 ## Complete code example
 
 This example requires SPC and ZAP files present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP Files for Protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire SPC and ZAP files from the original Timex Datalink software.
 
 Here is an example that syncs all models to a device that supports protocol 3:

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -158,7 +158,7 @@ TimexDatalinkClient::Protocol4::Alarm.new(
 ![image](https://user-images.githubusercontent.com/820984/190347561-eab2353d-90d0-44b5-aa69-eb58c4e1c4d4.png)
 
 This example requires a ZAP file present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP Files for Protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire ZAP files from the original Timex Datalink software.
 
 ```ruby
@@ -170,7 +170,7 @@ TimexDatalinkClient::Protocol4::WristApp.new(zap_file: "TIMER13.ZAP")
 ![image](https://user-images.githubusercontent.com/820984/190347710-b57fe25b-95b1-49b6-a897-6ad6f2ffe1aa.png)
 
 This example requires a SPC file present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP Files for Protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire SPC files from the original Timex Datalink software.
 
 ```ruby
@@ -185,7 +185,7 @@ TimexDatalinkClient::Protocol4::SoundOptions.new(
 ## Complete code example
 
 This example requires SPC and ZAP files present to upload.  See the
-[Acquiring SPC and ZAP files for protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
+[Acquiring SPC and ZAP Files for Protocols 3 and 4 documentation](acquiring_spc_and_zap_files.md) for information
 on how to acquire SPC and ZAP files from the original Timex Datalink software.
 
 Here is an example that syncs all models to a device that supports protocol 4:


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/218!

Addresses a small nit that fixes the capitalization for the title in the "acquiring SPC and ZAP files" documentation.