### PR TITLE
Add DATE_FORMATS constant to protocol 3 and 4 Time models

### DIFF
--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -112,6 +112,16 @@ TimexDatalinkClient::Protocol3::Time.new(
 )
 ```
 
+These are the available keys for `DATE_FORMATS`, represented by
+[Ruby's `strftime` format](https://apidock.com/ruby/DateTime/strftime):
+
+- `:"%_m-%d-%y"`
+- `:"%_d-%m-%y"`
+- `:"%y-%m-%d"`
+- `:"%_m.%d.%y"`
+- `:"%_d.%m.%y"`
+- `:"%y.%m.%d"`
+
 ## Alarms
 
 ![image](https://user-images.githubusercontent.com/820984/190345616-e011cb73-8a71-49c5-84df-48b539a20e56.png)

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -100,7 +100,7 @@ TimexDatalinkClient::Protocol3::Time.new(
   name: "PDT",
   time: Time.new(2022, 9, 5, 3, 39, 44),
   is_24h: false,
-  date_format: 2
+  date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
 )
 
 TimexDatalinkClient::Protocol3::Time.new(
@@ -108,7 +108,7 @@ TimexDatalinkClient::Protocol3::Time.new(
   name: "GMT",
   time: Time.new(2022, 9, 5, 11, 39, 44),
   is_24h: true,
-  date_format: 2
+  date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
 )
 ```
 
@@ -254,13 +254,13 @@ models = [
     zone: 1,
     time: time1,
     is_24h: false,
-    date_format: 2
+    date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
   ),
   TimexDatalinkClient::Protocol3::Time.new(
     zone: 2,
     time: time2,
     is_24h: true,
-    date_format: 2
+    date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
   ),
 
   TimexDatalinkClient::Protocol3::Alarm.new(

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -112,6 +112,16 @@ TimexDatalinkClient::Protocol4::Time.new(
 )
 ```
 
+These are the available keys for `DATE_FORMATS`, represented by
+[Ruby's `strftime` format](https://apidock.com/ruby/DateTime/strftime):
+
+- `:"%_m-%d-%y"`
+- `:"%_d-%m-%y"`
+- `:"%y-%m-%d"`
+- `:"%_m.%d.%y"`
+- `:"%_d.%m.%y"`
+- `:"%y.%m.%d"`
+
 ## Alarms
 
 ![image](https://user-images.githubusercontent.com/820984/190345616-e011cb73-8a71-49c5-84df-48b539a20e56.png)

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -100,7 +100,7 @@ TimexDatalinkClient::Protocol4::Time.new(
   name: "PDT",
   time: Time.new(2022, 9, 5, 3, 39, 44),
   is_24h: false,
-  date_format: 2
+  date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
 )
 
 TimexDatalinkClient::Protocol4::Time.new(
@@ -108,7 +108,7 @@ TimexDatalinkClient::Protocol4::Time.new(
   name: "GMT",
   time: Time.new(2022, 9, 5, 11, 39, 44),
   is_24h: true,
-  date_format: 2
+  date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
 )
 ```
 
@@ -254,13 +254,13 @@ models = [
     zone: 1,
     time: time1,
     is_24h: false,
-    date_format: 2
+    date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
   ),
   TimexDatalinkClient::Protocol4::Time.new(
     zone: 2,
     time: time2,
     is_24h: true,
-    date_format: 2
+    date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
   ),
 
   TimexDatalinkClient::Protocol4::Alarm.new(

--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -11,6 +11,15 @@ class TimexDatalinkClient
 
       CPACKET_TIME = [0x32]
 
+      DATE_FORMATS = {
+        "%_m-%d-%y": 0,
+        "%_d-%m-%y": 1,
+        "%y-%m-%d": 2,
+        "%_m.%d.%y": 4,
+        "%_d.%m.%y": 5,
+        "%y.%m.%d": 6
+      }.freeze
+
       attr_accessor :zone, :is_24h, :date_format, :time
 
       # Create a Time instance.

--- a/lib/timex_datalink_client/protocol_4/time.rb
+++ b/lib/timex_datalink_client/protocol_4/time.rb
@@ -11,6 +11,15 @@ class TimexDatalinkClient
 
       CPACKET_TIME = [0x32]
 
+      DATE_FORMATS = {
+        "%_m-%d-%y": 0,
+        "%_d-%m-%y": 1,
+        "%y-%m-%d": 2,
+        "%_m.%d.%y": 4,
+        "%_d.%m.%y": 5,
+        "%y.%m.%d": 6
+      }.freeze
+
       attr_accessor :zone, :is_24h, :date_format, :time
 
       # Create a Time instance.

--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -22,6 +22,23 @@ describe TimexDatalinkClient::Protocol3::Time do
     )
   end
 
+  describe "DATE_FORMATS" do
+    subject(:date_formats) { described_class::DATE_FORMATS }
+
+    let(:expected_date_formats) do
+      {
+        "%_m-%d-%y": 0,
+        "%_d-%m-%y": 1,
+        "%y-%m-%d": 2,
+        "%_m.%d.%y": 4,
+        "%_d.%m.%y": 5,
+        "%y.%m.%d": 6
+      }
+    end
+
+    it { should eq(expected_date_formats) }
+  end
+
   describe "#packets", :crc do
     subject(:packets) { time_instance.packets }
 

--- a/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
@@ -22,6 +22,23 @@ describe TimexDatalinkClient::Protocol4::Time do
     )
   end
 
+  describe "DATE_FORMATS" do
+    subject(:date_formats) { described_class::DATE_FORMATS }
+
+    let(:expected_date_formats) do
+      {
+        "%_m-%d-%y": 0,
+        "%_d-%m-%y": 1,
+        "%y-%m-%d": 2,
+        "%_m.%d.%y": 4,
+        "%_d.%m.%y": 5,
+        "%y.%m.%d": 6
+      }
+    end
+
+    it { should eq(expected_date_formats) }
+  end
+
   describe "#packets", :crc do
     subject(:packets) { time_instance.packets }
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/45!
Fixes https://github.com/synthead/timex_datalink_client/issues/179!

This PR adds `DATE_FORMATS` to protocol 3 and 4 Time models.  This lets users pick a date format based on a date format.  The formats are documented in https://apidock.com/ruby/DateTime/strftime.

The available date formats can be seen by calling `TimexDatalinkClient::Protocol3::Time::DATE_FORMATS` from a ruby console.  This will reveal this hash:

```ruby
{
  :"%_m-%d-%y" => 0,
  :"%_d-%m-%y" => 1,
  :"%y-%m-%d" => 2,
  :"%_m.%d.%y" => 4,
  :"%_d.%m.%y" => 5,
  :"%y.%m.%d" => 6
}
```

Any of these keys can be used when creating a `Time` model for protocol 3 and 4:

```ruby
TimexDatalinkClient::Protocol4::Time.new(
  zone: 1,
  time: time1,
  is_24h: false,
  date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
)
```

The values of the `DATE_FORMATS` hashes are integers, and users are still free to pass an integer to the `date_format` param, if they'd like:

```ruby
TimexDatalinkClient::Protocol4::Time.new(
  zone: 1,
  time: time1,
  is_24h: false,
  date_format: 0
)
```

Values 3 and 7 seem to produce buggy date stamps, so these are omitted.  Here is a map of the date formats and its integer (from https://github.com/synthead/timex_datalink_client/issues/45):

|date_format|format|
|---|---|
|0|`%_m-%d-%y`|
|1|`%_d-%m-%y`|
|2|`%y-%m-%d`|
|3|`C-%m-%d`|
|4|`%_m.%d.%y`|
|5|`%_d.%m.%y`|
|6|`%y.%m.%d`|
|7|`C.%m.%d`|

cc @rebellixx, who filed issue https://github.com/synthead/timex_datalink_client/issues/179, which is resolved by this PR :+1: 