### PR TITLE
Use symbols for Protocol9::Timer's action_at_end parameter

### DIFF
--- a/docs/timex_ironman_triathlon_protocol_9.md
+++ b/docs/timex_ironman_triathlon_protocol_9.md
@@ -57,37 +57,45 @@ TimexDatalinkClient::Protocol9::Timer.new(
   number: 1,
   label: "TIMER 1",
   time: Time.new(0, 1, 1, 0, 5, 0),  # Year, month, and day is ignored.
-  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
+  action_at_end: :stop_timer
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 2,
   label: "TIMER 2",
   time: Time.new(0, 1, 1, 0, 10, 0),  # Year, month, and day is ignored.
-  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
+  action_at_end: :repeat_timer
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 3,
   label: "TIMER 3",
   time: Time.new(0, 1, 1, 0, 15, 0),  # Year, month, and day is ignored.
-  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
+  action_at_end: :repeat_timer
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 4,
   label: "TIMER 4",
   time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
-  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
+  action_at_end: :stop_timer
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 5,
   label: "TIMER 5",
   time: Time.new(0, 1, 1, 1, 0, 0),  # Year, month, and day is ignored.
-  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:start_chrono]
+  action_at_end: :start_chrono
 )
 ```
+
+Here are the available values from the Timex Ironman Triathlon software with their equivalent `action_at_end` values:
+
+|Timex Ironman Triathlon value|`action_at_end` value|
+|---|---|
+|Stop Timer|`:stop_timer`|
+|Repeat Timer|`:repeat_timer`|
+|Start Chrono|`:start_chrono`|
 
 ## Alarms
 
@@ -259,31 +267,31 @@ models = [
     number: 1,
     label: "TIMER 1",
     time: Time.new(0, 1, 1, 0, 5, 0),  # Year, month, and day is ignored.
-    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
+    action_at_end: :stop_timer
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 2,
     label: "TIMER 2",
     time: Time.new(0, 1, 1, 0, 10, 0),  # Year, month, and day is ignored.
-    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
+    action_at_end: :repeat_timer
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 3,
     label: "TIMER 3",
     time: Time.new(0, 1, 1, 0, 15, 0),  # Year, month, and day is ignored.
-    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
+    action_at_end: :repeat_timer
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 4,
     label: "TIMER 4",
     time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
-    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
+    action_at_end: :stop_timer
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 5,
     label: "TIMER 5",
     time: Time.new(0, 1, 1, 1, 0, 0),  # Year, month, and day is ignored.
-    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:start_chrono]
+    action_at_end: :start_chrono
   ),
 
   TimexDatalinkClient::Protocol9::Alarm.new(

--- a/docs/timex_ironman_triathlon_protocol_9.md
+++ b/docs/timex_ironman_triathlon_protocol_9.md
@@ -57,35 +57,35 @@ TimexDatalinkClient::Protocol9::Timer.new(
   number: 1,
   label: "TIMER 1",
   time: Time.new(0, 1, 1, 0, 5, 0),  # Year, month, and day is ignored.
-  action_at_end: 0
+  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 2,
   label: "TIMER 2",
   time: Time.new(0, 1, 1, 0, 10, 0),  # Year, month, and day is ignored.
-  action_at_end: 1
+  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 3,
   label: "TIMER 3",
   time: Time.new(0, 1, 1, 0, 15, 0),  # Year, month, and day is ignored.
-  action_at_end: 1
+  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 4,
   label: "TIMER 4",
   time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
-  action_at_end: 0
+  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
 )
 
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 5,
   label: "TIMER 5",
   time: Time.new(0, 1, 1, 1, 0, 0),  # Year, month, and day is ignored.
-  action_at_end: 2
+  action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:start_chrono]
 )
 ```
 
@@ -259,31 +259,31 @@ models = [
     number: 1,
     label: "TIMER 1",
     time: Time.new(0, 1, 1, 0, 5, 0),  # Year, month, and day is ignored.
-    action_at_end: 0
+    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 2,
     label: "TIMER 2",
     time: Time.new(0, 1, 1, 0, 10, 0),  # Year, month, and day is ignored.
-    action_at_end: 1
+    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 3,
     label: "TIMER 3",
     time: Time.new(0, 1, 1, 0, 15, 0),  # Year, month, and day is ignored.
-    action_at_end: 1
+    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:repeat_timer]
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 4,
     label: "TIMER 4",
     time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
-    action_at_end: 0
+    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:stop_timer]
   ),
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 5,
     label: "TIMER 5",
     time: Time.new(0, 1, 1, 1, 0, 0),  # Year, month, and day is ignored.
-    action_at_end: 2
+    action_at_end: TimexDatalinkClient::Protocol9::Timer::ACTIONS_AT_END[:start_chrono]
   ),
 
   TimexDatalinkClient::Protocol9::Alarm.new(

--- a/lib/timex_datalink_client/protocol_9/timer.rb
+++ b/lib/timex_datalink_client/protocol_9/timer.rb
@@ -24,7 +24,7 @@ class TimexDatalinkClient
       # @param number [Integer] Entry number for timer.
       # @param label [String] Label for timer.
       # @param time [Time] Time of timer.
-      # @param action_at_end [Integer] Action at end of timer.
+      # @param action_at_end [:stop_timer, :repeat_timer, :start_chrono] Action at end of timer.
       # @return [Timer] Timer instance.
       def initialize(number:, label:, time:, action_at_end:)
         @number = number
@@ -44,13 +44,17 @@ class TimexDatalinkClient
             time.hour,
             time.min,
             time.sec,
-            action_at_end,
+            action_at_end_value,
             label_characters
           ].flatten
         ]
       end
 
       private
+
+      def action_at_end_value
+        ACTION_AT_END_MAP.fetch(action_at_end)
+      end
 
       def label_characters
         chars_for(label, length: 8, pad: true)

--- a/lib/timex_datalink_client/protocol_9/timer.rb
+++ b/lib/timex_datalink_client/protocol_9/timer.rb
@@ -11,7 +11,7 @@ class TimexDatalinkClient
 
       CPACKET_TIMER = [0x43]
 
-      ACTIONS_AT_END = {
+      ACTION_AT_END_MAP = {
         stop_timer: 0,
         repeat_timer: 1,
         start_chrono: 2

--- a/lib/timex_datalink_client/protocol_9/timer.rb
+++ b/lib/timex_datalink_client/protocol_9/timer.rb
@@ -11,6 +11,12 @@ class TimexDatalinkClient
 
       CPACKET_TIMER = [0x43]
 
+      ACTIONS_AT_END = {
+        stop_timer: 0,
+        repeat_timer: 1,
+        start_chrono: 2
+      }.freeze
+
       attr_accessor :number, :label, :time, :action_at_end
 
       # Create a Timer instance.

--- a/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
@@ -6,7 +6,7 @@ describe TimexDatalinkClient::Protocol9::Timer do
   let(:number) { 1 }
   let(:label) { "Timer 1" }
   let(:time) { Time.new(0, 1, 1, 1, 2, 3) }
-  let(:action_at_end) { 0 }
+  let(:action_at_end) { :stop_timer }
 
   let(:timer) do
     described_class.new(
@@ -15,20 +15,6 @@ describe TimexDatalinkClient::Protocol9::Timer do
       time: time,
       action_at_end: action_at_end
     )
-  end
-
-  describe "ACTIONS_AT_END" do
-    subject(:actions_at_end) { described_class::ACTIONS_AT_END }
-
-    let(:expected_actions_at_end) do
-      {
-        stop_timer: 0,
-        repeat_timer: 1,
-        start_chrono: 2
-      }
-    end
-
-    it { should eq(expected_actions_at_end) }
   end
 
   describe "#packets", :crc do
@@ -78,8 +64,16 @@ describe TimexDatalinkClient::Protocol9::Timer do
       ]
     end
 
-    context "when action_at_end is 2" do
-      let(:action_at_end) { 2 }
+    context "when action_at_end is :repeat_timer" do
+      let(:action_at_end) { :repeat_timer }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x43, 0x01, 0x01, 0x02, 0x03, 0x01, 0x1d, 0x12, 0x16, 0x0e, 0x1b, 0x24, 0x01, 0x24]
+      ]
+    end
+
+    context "when action_at_end is :start_chrono" do
+      let(:action_at_end) { :start_chrono }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x43, 0x01, 0x01, 0x02, 0x03, 0x02, 0x1d, 0x12, 0x16, 0x0e, 0x1b, 0x24, 0x01, 0x24]

--- a/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/timer_spec.rb
@@ -17,6 +17,20 @@ describe TimexDatalinkClient::Protocol9::Timer do
     )
   end
 
+  describe "ACTIONS_AT_END" do
+    subject(:actions_at_end) { described_class::ACTIONS_AT_END }
+
+    let(:expected_actions_at_end) do
+      {
+        stop_timer: 0,
+        repeat_timer: 1,
+        start_chrono: 2
+      }
+    end
+
+    it { should eq(expected_actions_at_end) }
+  end
+
   describe "#packets", :crc do
     subject(:packets) { timer.packets }
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/147!

This PR clears up Protocol9::Timer's action_at_end parameter a bit by using symbol values instead of raw integers for its data.

Here's a screenshot of the Timers settings in the Timex Ironman Triathlon software:

![image](https://user-images.githubusercontent.com/820984/209271410-c7c54cad-3885-4fcd-86bd-08caaa3e3194.png)

Here's a comparison of the the values from the original software, the old valid values (before this PR), and the new valid values (with this PR):

|Ironman software value|Old action_at_end value|New action_at_end value|
|---|---|---|
|Stop Timer|`0`|`:stop_timer`|
|Repeat Timer|`1`|`:repeat_timer`|
|Start Chrono|`2`|`:start_chrono`|

Here's an example of how to create protocol 9 `Timer` models with the new symbol values (this is identical to the screenshot above):

```ruby
TimexDatalinkClient::Protocol9::Timer.new(
  number: 1,
  label: "TIMER 1",
  time: Time.new(0, 1, 1, 0, 5, 0),  # Year, month, and day is ignored.
  action_at_end: :stop_timer
)

TimexDatalinkClient::Protocol9::Timer.new(
  number: 2,
  label: "TIMER 2",
  time: Time.new(0, 1, 1, 0, 10, 0),  # Year, month, and day is ignored.
  action_at_end: :repeat_timer
)

TimexDatalinkClient::Protocol9::Timer.new(
  number: 3,
  label: "TIMER 3",
  time: Time.new(0, 1, 1, 0, 15, 0),  # Year, month, and day is ignored.
  action_at_end: :repeat_timer
)

TimexDatalinkClient::Protocol9::Timer.new(
  number: 4,
  label: "TIMER 4",
  time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
  action_at_end: :stop_timer
)

TimexDatalinkClient::Protocol9::Timer.new(
  number: 5,
  label: "TIMER 5",
  time: Time.new(0, 1, 1, 1, 0, 0),  # Year, month, and day is ignored.
  action_at_end: :start_chrono
)
```