### PR TITLE
Use Time#strftime values for protocol 3 and 4 Time date_format parameter

### DIFF
--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -100,7 +100,7 @@ TimexDatalinkClient::Protocol3::Time.new(
   name: "PDT",
   time: Time.new(2022, 9, 5, 3, 39, 44),
   is_24h: false,
-  date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
+  date_format: "%_m-%d-%y"
 )
 
 TimexDatalinkClient::Protocol3::Time.new(
@@ -108,19 +108,22 @@ TimexDatalinkClient::Protocol3::Time.new(
   name: "GMT",
   time: Time.new(2022, 9, 5, 11, 39, 44),
   is_24h: true,
-  date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
+  date_format: "%_m-%d-%y"
 )
 ```
 
-These are the available keys for `DATE_FORMATS`, represented by
-[Ruby's `strftime` format](https://apidock.com/ruby/DateTime/strftime):
+Here are the valid values for `action_at_end`, represented by
+[Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2015-10-21 in `%Y-%m-%d`
+format:
 
-- `:"%_m-%d-%y"`
-- `:"%_d-%m-%y"`
-- `:"%y-%m-%d"`
-- `:"%_m.%d.%y"`
-- `:"%_d.%m.%y"`
-- `:"%y.%m.%d"`
+|`date_format` value|Formatted example|
+|---|---|
+|`"%_m-%d-%y"`|`10-21-15`|
+|`"%_d-%m-%y"`|`21-10-15`|
+|`"%y-%m-%d"`|`15-10-21`|
+|`"%_m.%d.%y"`|`10.21.15`|
+|`"%_d.%m.%y"`|`21.10.15`|
+|`"%y.%m.%d"`|`15.10.21`|
 
 ## Alarms
 
@@ -264,13 +267,13 @@ models = [
     zone: 1,
     time: time1,
     is_24h: false,
-    date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
+    date_format: "%_m-%d-%y"
   ),
   TimexDatalinkClient::Protocol3::Time.new(
     zone: 2,
     time: time2,
     is_24h: true,
-    date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
+    date_format: "%_m-%d-%y"
   ),
 
   TimexDatalinkClient::Protocol3::Alarm.new(

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -113,17 +113,17 @@ TimexDatalinkClient::Protocol3::Time.new(
 ```
 
 Here are the valid values for `action_at_end`, represented by
-[Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2015-10-21 in `%Y-%m-%d`
+[Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2023-09-06 in `%Y-%m-%d`
 format:
 
 |`date_format` value|Formatted example|
 |---|---|
-|`"%_m-%d-%y"`|`10-21-15`|
-|`"%_d-%m-%y"`|`21-10-15`|
-|`"%y-%m-%d"`|`15-10-21`|
-|`"%_m.%d.%y"`|`10.21.15`|
-|`"%_d.%m.%y"`|`21.10.15`|
-|`"%y.%m.%d"`|`15.10.21`|
+|`"%_m-%d-%y"`|` 9-06-23`|
+|`"%_d-%m-%y"`|` 6-09-23`|
+|`"%y-%m-%d"`|`23-09-06`|
+|`"%_m.%d.%y"`|` 9.06.23`|
+|`"%_d.%m.%y"`|` 6.09.23`|
+|`"%y.%m.%d"`|`23.09.06`|
 
 ## Alarms
 

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -113,17 +113,17 @@ TimexDatalinkClient::Protocol4::Time.new(
 ```
 
 Here are the valid values for `action_at_end`, represented by
-[Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2015-10-21 in `%Y-%m-%d`
+[Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2023-09-06 in `%Y-%m-%d`
 format:
 
 |`date_format` value|Formatted example|
 |---|---|
-|`"%_m-%d-%y"`|`10-21-15`|
-|`"%_d-%m-%y"`|`21-10-15`|
-|`"%y-%m-%d"`|`15-10-21`|
-|`"%_m.%d.%y"`|`10.21.15`|
-|`"%_d.%m.%y"`|`21.10.15`|
-|`"%y.%m.%d"`|`15.10.21`|
+|`"%_m-%d-%y"`|` 9-06-23`|
+|`"%_d-%m-%y"`|` 6-09-23`|
+|`"%y-%m-%d"`|`23-09-06`|
+|`"%_m.%d.%y"`|` 9.06.23`|
+|`"%_d.%m.%y"`|` 6.09.23`|
+|`"%y.%m.%d"`|`23.09.06`|
 
 ## Alarms
 

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -100,7 +100,7 @@ TimexDatalinkClient::Protocol4::Time.new(
   name: "PDT",
   time: Time.new(2022, 9, 5, 3, 39, 44),
   is_24h: false,
-  date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
+  date_format: "%_m-%d-%y"
 )
 
 TimexDatalinkClient::Protocol4::Time.new(
@@ -108,19 +108,22 @@ TimexDatalinkClient::Protocol4::Time.new(
   name: "GMT",
   time: Time.new(2022, 9, 5, 11, 39, 44),
   is_24h: true,
-  date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
+  date_format: "%_m-%d-%y"
 )
 ```
 
-These are the available keys for `DATE_FORMATS`, represented by
-[Ruby's `strftime` format](https://apidock.com/ruby/DateTime/strftime):
+Here are the valid values for `action_at_end`, represented by
+[Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2015-10-21 in `%Y-%m-%d`
+format:
 
-- `:"%_m-%d-%y"`
-- `:"%_d-%m-%y"`
-- `:"%y-%m-%d"`
-- `:"%_m.%d.%y"`
-- `:"%_d.%m.%y"`
-- `:"%y.%m.%d"`
+|`date_format` value|Formatted example|
+|---|---|
+|`"%_m-%d-%y"`|`10-21-15`|
+|`"%_d-%m-%y"`|`21-10-15`|
+|`"%y-%m-%d"`|`15-10-21`|
+|`"%_m.%d.%y"`|`10.21.15`|
+|`"%_d.%m.%y"`|`21.10.15`|
+|`"%y.%m.%d"`|`15.10.21`|
 
 ## Alarms
 
@@ -264,13 +267,13 @@ models = [
     zone: 1,
     time: time1,
     is_24h: false,
-    date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
+    date_format: "%_m-%d-%y"
   ),
   TimexDatalinkClient::Protocol4::Time.new(
     zone: 2,
     time: time2,
     is_24h: true,
-    date_format: TimexDatalinkClient::Protocol4::Time::DATE_FORMATS[:"%_m-%d-%y"]
+    date_format: "%_m-%d-%y"
   ),
 
   TimexDatalinkClient::Protocol4::Alarm.new(

--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -11,7 +11,7 @@ class TimexDatalinkClient
 
       CPACKET_TIME = [0x32]
 
-      DATE_FORMATS = {
+      DATE_FORMAT_MAP = {
         "%_m-%d-%y": 0,
         "%_d-%m-%y": 1,
         "%y-%m-%d": 2,
@@ -26,7 +26,8 @@ class TimexDatalinkClient
       #
       # @param zone [Integer] Time zone number (1 or 2).
       # @param is_24h [Boolean] Toggle 24 hour time.
-      # @param date_format [Integer] Date format.
+      # @param date_format [:"%_m-%d-%y", :"%_d-%m-%y", :"%y-%m-%d", :"%_m.%d.%y", :"%_d.%m.%y", :"%y.%m.%d"] Date
+      #   format (represented by Time#strftime format).
       # @param time [::Time] Time to set (including time zone).
       # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max)
       # @return [Time] Time instance.
@@ -55,7 +56,7 @@ class TimexDatalinkClient
             name_characters,
             wday_from_monday,
             is_24h_value,
-            date_format
+            date_format_value
           ].flatten
         ]
       end
@@ -80,6 +81,10 @@ class TimexDatalinkClient
 
       def is_24h_value
         is_24h ? 2 : 1
+      end
+
+      def date_format_value
+        DATE_FORMAT_MAP.fetch(date_format)
       end
     end
   end

--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -12,12 +12,12 @@ class TimexDatalinkClient
       CPACKET_TIME = [0x32]
 
       DATE_FORMAT_MAP = {
-        "%_m-%d-%y": 0,
-        "%_d-%m-%y": 1,
-        "%y-%m-%d": 2,
-        "%_m.%d.%y": 4,
-        "%_d.%m.%y": 5,
-        "%y.%m.%d": 6
+        "%_m-%d-%y" => 0,
+        "%_d-%m-%y" => 1,
+        "%y-%m-%d" => 2,
+        "%_m.%d.%y" => 4,
+        "%_d.%m.%y" => 5,
+        "%y.%m.%d" => 6
       }.freeze
 
       attr_accessor :zone, :is_24h, :date_format, :time
@@ -26,8 +26,8 @@ class TimexDatalinkClient
       #
       # @param zone [Integer] Time zone number (1 or 2).
       # @param is_24h [Boolean] Toggle 24 hour time.
-      # @param date_format [:"%_m-%d-%y", :"%_d-%m-%y", :"%y-%m-%d", :"%_m.%d.%y", :"%_d.%m.%y", :"%y.%m.%d"] Date
-      #   format (represented by Time#strftime format).
+      # @param date_format ["%_m-%d-%y", "%_d-%m-%y", "%y-%m-%d", "%_m.%d.%y", "%_d.%m.%y", "%y.%m.%d"] Date format
+      #   (represented by Time#strftime format).
       # @param time [::Time] Time to set (including time zone).
       # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max)
       # @return [Time] Time instance.

--- a/lib/timex_datalink_client/protocol_4/time.rb
+++ b/lib/timex_datalink_client/protocol_4/time.rb
@@ -11,13 +11,13 @@ class TimexDatalinkClient
 
       CPACKET_TIME = [0x32]
 
-      DATE_FORMATS = {
-        "%_m-%d-%y": 0,
-        "%_d-%m-%y": 1,
-        "%y-%m-%d": 2,
-        "%_m.%d.%y": 4,
-        "%_d.%m.%y": 5,
-        "%y.%m.%d": 6
+      DATE_FORMAT_MAP = {
+        "%_m-%d-%y" => 0,
+        "%_d-%m-%y" => 1,
+        "%y-%m-%d" => 2,
+        "%_m.%d.%y" => 4,
+        "%_d.%m.%y" => 5,
+        "%y.%m.%d" => 6
       }.freeze
 
       attr_accessor :zone, :is_24h, :date_format, :time
@@ -26,7 +26,8 @@ class TimexDatalinkClient
       #
       # @param zone [Integer] Time zone number (1 or 2).
       # @param is_24h [Boolean] Toggle 24 hour time.
-      # @param date_format [Integer] Date format.
+      # @param date_format ["%_m-%d-%y", "%_d-%m-%y", "%y-%m-%d", "%_m.%d.%y", "%_d.%m.%y", "%y.%m.%d"] Date format
+      #   (represented by Time#strftime format).
       # @param time [::Time] Time to set (including time zone).
       # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max)
       # @return [Time] Time instance.
@@ -55,7 +56,7 @@ class TimexDatalinkClient
             name_characters,
             wday_from_monday,
             is_24h_value,
-            date_format
+            date_format_value
           ].flatten
         ]
       end
@@ -80,6 +81,10 @@ class TimexDatalinkClient
 
       def is_24h_value
         is_24h ? 2 : 1
+      end
+
+      def date_format_value
+        DATE_FORMAT_MAP.fetch(date_format)
       end
     end
   end

--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 describe TimexDatalinkClient::Protocol3::Time do
   let(:zone) { 1 }
   let(:is_24h) { false }
-  let(:date_format) { :"%_m-%d-%y" }
+  let(:date_format) { "%_m-%d-%y" }
   let(:tzinfo) { TZInfo::Timezone.get("US/Pacific") }
   let(:time) { tzinfo.local_time(2015, 10, 21, 19, 28, 32) }
   let(:name) { nil }
@@ -45,40 +45,40 @@ describe TimexDatalinkClient::Protocol3::Time do
       ]
     end
 
-    context "when date_format is :\"%_d-%m-%y\"" do
-      let(:date_format) { :"%_d-%m-%y" }
+    context "when date_format is \"%_d-%m-%y\"" do
+      let(:date_format) { "%_d-%m-%y" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x01]
       ]
     end
 
-    context "when date_format is :\"%y-%m-%d\"" do
-      let(:date_format) { :"%y-%m-%d" }
+    context "when date_format is \"%y-%m-%d\"" do
+      let(:date_format) { "%y-%m-%d" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x02]
       ]
     end
 
-    context "when date_format is :\"%_m.%d.%y\"" do
-      let(:date_format) { :"%_m.%d.%y" }
+    context "when date_format is \"%_m.%d.%y\"" do
+      let(:date_format) { "%_m.%d.%y" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x04]
       ]
     end
 
-    context "when date_format is :\"%_d.%m.%y\"" do
-      let(:date_format) { :"%_d.%m.%y" }
+    context "when date_format is \"%_d.%m.%y\"" do
+      let(:date_format) { "%_d.%m.%y" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x05]
       ]
     end
 
-    context "when date_format is :\"%y.%m.%d\"" do
-      let(:date_format) { :"%y.%m.%d" }
+    context "when date_format is \"%y.%m.%d\"" do
+      let(:date_format) { "%y.%m.%d" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x06]

--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 describe TimexDatalinkClient::Protocol3::Time do
   let(:zone) { 1 }
   let(:is_24h) { false }
-  let(:date_format) { 0 }
+  let(:date_format) { :"%_m-%d-%y" }
   let(:tzinfo) { TZInfo::Timezone.get("US/Pacific") }
   let(:time) { tzinfo.local_time(2015, 10, 21, 19, 28, 32) }
   let(:name) { nil }
@@ -20,23 +20,6 @@ describe TimexDatalinkClient::Protocol3::Time do
       time: time,
       name: name
     )
-  end
-
-  describe "DATE_FORMATS" do
-    subject(:date_formats) { described_class::DATE_FORMATS }
-
-    let(:expected_date_formats) do
-      {
-        "%_m-%d-%y": 0,
-        "%_d-%m-%y": 1,
-        "%y-%m-%d": 2,
-        "%_m.%d.%y": 4,
-        "%_d.%m.%y": 5,
-        "%y.%m.%d": 6
-      }
-    end
-
-    it { should eq(expected_date_formats) }
   end
 
   describe "#packets", :crc do
@@ -62,11 +45,43 @@ describe TimexDatalinkClient::Protocol3::Time do
       ]
     end
 
-    context "when date_format is 4" do
-      let(:date_format) { 4 }
+    context "when date_format is :\"%_d-%m-%y\"" do
+      let(:date_format) { :"%_d-%m-%y" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x01]
+      ]
+    end
+
+    context "when date_format is :\"%y-%m-%d\"" do
+      let(:date_format) { :"%y-%m-%d" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x02]
+      ]
+    end
+
+    context "when date_format is :\"%_m.%d.%y\"" do
+      let(:date_format) { :"%_m.%d.%y" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x04]
+      ]
+    end
+
+    context "when date_format is :\"%_d.%m.%y\"" do
+      let(:date_format) { :"%_d.%m.%y" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x05]
+      ]
+    end
+
+    context "when date_format is :\"%y.%m.%d\"" do
+      let(:date_format) { :"%y.%m.%d" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x06]
       ]
     end
 

--- a/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 describe TimexDatalinkClient::Protocol4::Time do
   let(:zone) { 1 }
   let(:is_24h) { false }
-  let(:date_format) { 0 }
+  let(:date_format) { "%_m-%d-%y" }
   let(:tzinfo) { TZInfo::Timezone.get("US/Pacific") }
   let(:time) { tzinfo.local_time(2015, 10, 21, 19, 28, 32) }
   let(:name) { nil }
@@ -20,23 +20,6 @@ describe TimexDatalinkClient::Protocol4::Time do
       time: time,
       name: name
     )
-  end
-
-  describe "DATE_FORMATS" do
-    subject(:date_formats) { described_class::DATE_FORMATS }
-
-    let(:expected_date_formats) do
-      {
-        "%_m-%d-%y": 0,
-        "%_d-%m-%y": 1,
-        "%y-%m-%d": 2,
-        "%_m.%d.%y": 4,
-        "%_d.%m.%y": 5,
-        "%y.%m.%d": 6
-      }
-    end
-
-    it { should eq(expected_date_formats) }
   end
 
   describe "#packets", :crc do
@@ -62,11 +45,43 @@ describe TimexDatalinkClient::Protocol4::Time do
       ]
     end
 
-    context "when date_format is 4" do
-      let(:date_format) { 4 }
+    context "when date_format is \"%_d-%m-%y\"" do
+      let(:date_format) { "%_d-%m-%y" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x01]
+      ]
+    end
+
+    context "when date_format is \"%y-%m-%d\"" do
+      let(:date_format) { "%y-%m-%d" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x02]
+      ]
+    end
+
+    context "when date_format is \"%_m.%d.%y\"" do
+      let(:date_format) { "%_m.%d.%y" }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x04]
+      ]
+    end
+
+    context "when date_format is \"%_d.%m.%y\"" do
+      let(:date_format) { "%_d.%m.%y" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x05]
+      ]
+    end
+
+    context "when date_format is \"%y.%m.%d\"" do
+      let(:date_format) { "%y.%m.%d" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x19, 0x0d, 0x1d, 0x02, 0x01, 0x06]
       ]
     end
 

--- a/spec/lib/timex_datalink_client_spec.rb
+++ b/spec/lib/timex_datalink_client_spec.rb
@@ -17,7 +17,7 @@ describe TimexDatalinkClient do
       TimexDatalinkClient::Protocol3::Time.new(
         zone: 1,
         is_24h: false,
-        date_format: 0,
+        date_format: "%_m-%d-%y",
         time: TZInfo::Timezone.get("US/Pacific").local_time(2015, 10, 21, 19, 28, 32)
       ),
       TimexDatalinkClient::Protocol3::Eeprom.new(


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/222!

With https://github.com/synthead/timex_datalink_client/pull/220 shipped, protocols 3 and 4 now follow this pattern:

```ruby
TimexDatalinkClient::Protocol3::Time.new(
  zone: 1,
  name: "PDT",
  time: Time.new(2022, 9, 5, 3, 39, 44),
  is_24h: false,
  date_format: TimexDatalinkClient::Protocol3::Time::DATE_FORMATS[:"%_m-%d-%y"]
)
```

There are only a handful of date formats that are valid for protocols 3 and 4, this PR simplifies the `date_format` param to:

```ruby
TimexDatalinkClient::Protocol3::Time.new(
  zone: 1,
  name: "PDT",
  time: Time.new(2022, 9, 5, 3, 39, 44),
  is_24h: false,
  date_format: "%_m-%d-%y"
)
```

Here's an excerpt from the documentation updates in this PR for the new `date_format` values:

> Here are the valid values for `action_at_end`, represented by [Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2023-09-06 in `%Y-%m-%d` format:
> 
> |`date_format` value|Formatted example|
> |---|---|
> |`"%_m-%d-%y"`|` 9-06-23`|
> |`"%_d-%m-%y"`|` 6-09-23`|
> |`"%y-%m-%d"`|`23-09-06`|
> |`"%_m.%d.%y"`|` 9.06.23`|
> |`"%_d.%m.%y"`|` 6.09.23`|
> |`"%y.%m.%d"`|`23.09.06`|


cc @rebellixx, who filed https://github.com/synthead/timex_datalink_client/issues/179 :+1: 