### PR TITLE
Add error handling to Eeprom::List's priority value for protocols 1, 3, and 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     timex_datalink_client (0.9.0)
+      activemodel (~> 7.0.4)
       crc (~> 0.4.2)
       mdb (~> 0.5.0)
       rubyserial (~> 0.6.0)
@@ -9,12 +10,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     backports (3.23.0)
     concurrent-ruby (1.1.10)
     crc (0.4.2)
     diff-lcs (1.5.0)
     ffi (1.15.5)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     mdb (0.5.0)
+    minitest (5.16.3)
     rainbow (3.1.1)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)

--- a/docs/timex_datalink_protocol_1.md
+++ b/docs/timex_datalink_protocol_1.md
@@ -93,6 +93,17 @@ lists = [
 TimexDatalinkClient::Protocol1::Eeprom.new(lists: lists)
 ```
 
+Here are the available Priority values from the Timex Datalink software with their equivalent `List` `priority` values:
+
+|Timex Datalink Priority value|`List` `priority` value|
+|---|---|
+|1 - Highest|`1`|
+|2 - High|`2`|
+|3 - Medium|`3`|
+|4 - Low|`4`|
+|5 - Lowest|`5`|
+|None|`nil`|
+
 ## Time Settings
 
 ![image](https://user-images.githubusercontent.com/820984/190338907-7fd94480-5898-4e46-b715-56565293d0c8.png)

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -90,6 +90,17 @@ lists = [
 TimexDatalinkClient::Protocol3::Eeprom.new(lists: lists)
 ```
 
+Here are the available Priority values from the Timex Datalink software with their equivalent `List` `priority` values:
+
+|Timex Datalink Priority value|`List` `priority` value|
+|---|---|
+|1 - Highest|`1`|
+|2 - High|`2`|
+|3 - Medium|`3`|
+|4 - Low|`4`|
+|5 - Lowest|`5`|
+|None|`nil`|
+
 ## Time Settings
 
 ![image](https://user-images.githubusercontent.com/820984/190338907-7fd94480-5898-4e46-b715-56565293d0c8.png)

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -90,6 +90,17 @@ lists = [
 TimexDatalinkClient::Protocol4::Eeprom.new(lists: lists)
 ```
 
+Here are the available Priority values from the Timex Datalink software with their equivalent `List` `priority` values:
+
+|Timex Datalink Priority value|`List` `priority` value|
+|---|---|
+|1 - Highest|`1`|
+|2 - High|`2`|
+|3 - Medium|`3`|
+|4 - Low|`4`|
+|5 - Lowest|`5`|
+|None|`nil`|
+
 ## Time Settings
 
 ![image](https://user-images.githubusercontent.com/820984/190338907-7fd94480-5898-4e46-b715-56565293d0c8.png)

--- a/lib/timex_datalink_client/protocol_1/eeprom/list.rb
+++ b/lib/timex_datalink_client/protocol_1/eeprom/list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/char_encoders"
 require "timex_datalink_client/helpers/length_packet_wrapper"
 
@@ -7,15 +9,23 @@ class TimexDatalinkClient
   class Protocol1
     class Eeprom
       class List
+        include ActiveModel::Validations
         include Helpers::CharEncoders
         prepend Helpers::LengthPacketWrapper
 
         attr_accessor :list_entry, :priority
 
+        validates :priority, inclusion: {
+          in: 1..5,
+          allow_nil: true,
+          message: "%{value} is invalid!  Valid priorities are 1..5 or nil."
+        }
+
         # Create a List instance.
         #
         # @param list_entry [String] List entry text.
         # @param priority [Integer] List priority.
+        # @raise [ActiveModel::ValidationError] One or more model values are invalid.
         # @return [List] List instance.
         def initialize(list_entry:, priority:)
           @list_entry = list_entry
@@ -26,8 +36,10 @@ class TimexDatalinkClient
         #
         # @return [Array<Integer>] Array of integers that represent bytes.
         def packet
+          validate!
+
           [
-            priority,
+            priority_value,
             list_entry_characters
           ].flatten
         end
@@ -36,6 +48,10 @@ class TimexDatalinkClient
 
         def list_entry_characters
           eeprom_chars_for(list_entry)
+        end
+
+        def priority_value
+          priority.nil? ? 0 : priority
         end
       end
     end

--- a/lib/timex_datalink_client/protocol_4/eeprom/list.rb
+++ b/lib/timex_datalink_client/protocol_4/eeprom/list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/char_encoders"
 require "timex_datalink_client/helpers/length_packet_wrapper"
 
@@ -7,10 +9,17 @@ class TimexDatalinkClient
   class Protocol4
     class Eeprom
       class List
+        include ActiveModel::Validations
         include Helpers::CharEncoders
         prepend Helpers::LengthPacketWrapper
 
         attr_accessor :list_entry, :priority
+
+        validates :priority, inclusion: {
+          in: 1..5,
+          allow_nil: true,
+          message: "%{value} is invalid!  Valid priorities are 1..5 or nil."
+        }
 
         # Create a List instance.
         #
@@ -26,8 +35,10 @@ class TimexDatalinkClient
         #
         # @return [Array<Integer>] Array of integers that represent bytes.
         def packet
+          validate!
+
           [
-            priority,
+            priority_value,
             list_entry_characters
           ].flatten
         end
@@ -36,6 +47,10 @@ class TimexDatalinkClient
 
         def list_entry_characters
           eeprom_chars_for(list_entry)
+        end
+
+        def priority_value
+          priority.nil? ? 0 : priority
         end
       end
     end

--- a/spec/lib/timex_datalink_client/protocol_1/eeprom/list_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/eeprom/list_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe TimexDatalinkClient::Protocol1::Eeprom::List do
   let(:list_entry) { "Muffler Bearings" }
-  let(:priority) { 0 }
+  let(:priority) { nil }
 
   let(:list) do
     described_class.new(
@@ -20,12 +20,42 @@ describe TimexDatalinkClient::Protocol1::Eeprom::List do
       0x00, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
     ]
 
-    context "when priority is 3" do
-      let(:priority) { 3 }
+    context "when priority is 1" do
+      let(:priority) { 1 }
 
       it_behaves_like "a length-prefixed packet", [
-        0x03, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
+        0x01, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
       ]
+    end
+
+    context "when priority is 5" do
+      let(:priority) { 5 }
+
+      it_behaves_like "a length-prefixed packet", [
+        0x05, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
+      ]
+    end
+
+    context "when priority is 0" do
+      let(:priority) { 0 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Priority 0 is invalid!  Valid priorities are 1..5 or nil."
+        )
+      end
+    end
+
+    context "when priority is 6" do
+      let(:priority) { 6 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Priority 6 is invalid!  Valid priorities are 1..5 or nil."
+        )
+      end
     end
 
     context "when list_entry is \"Headlight Fluid with More than 31 Characters\"" do

--- a/spec/lib/timex_datalink_client/protocol_1/eeprom_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/eeprom_spec.rb
@@ -48,11 +48,11 @@ describe TimexDatalinkClient::Protocol1::Eeprom do
     [
       TimexDatalinkClient::Protocol1::Eeprom::List.new(
         list_entry: "muffler bearings",
-        priority: 0
+        priority: nil
       ),
       TimexDatalinkClient::Protocol1::Eeprom::List.new(
         list_entry: "headlight fluid",
-        priority: 0
+        priority: nil
       )
     ]
   end

--- a/spec/lib/timex_datalink_client/protocol_3/eeprom/list_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/eeprom/list_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe TimexDatalinkClient::Protocol3::Eeprom::List do
   let(:list_entry) { "Muffler Bearings" }
-  let(:priority) { 0 }
+  let(:priority) { nil }
 
   let(:list) do
     described_class.new(
@@ -20,12 +20,42 @@ describe TimexDatalinkClient::Protocol3::Eeprom::List do
       0x00, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
     ]
 
-    context "when priority is 3" do
-      let(:priority) { 3 }
+    context "when priority is 1" do
+      let(:priority) { 1 }
 
       it_behaves_like "a length-prefixed packet", [
-        0x03, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
+        0x01, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
       ]
+    end
+
+    context "when priority is 5" do
+      let(:priority) { 5 }
+
+      it_behaves_like "a length-prefixed packet", [
+        0x05, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
+      ]
+    end
+
+    context "when priority is 0" do
+      let(:priority) { 0 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Priority 0 is invalid!  Valid priorities are 1..5 or nil."
+        )
+      end
+    end
+
+    context "when priority is 6" do
+      let(:priority) { 6 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Priority 6 is invalid!  Valid priorities are 1..5 or nil."
+        )
+      end
     end
 
     context "when list_entry is \"Headlight Fluid with More than 31 Characters\"" do

--- a/spec/lib/timex_datalink_client/protocol_3/eeprom_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/eeprom_spec.rb
@@ -48,11 +48,11 @@ describe TimexDatalinkClient::Protocol3::Eeprom do
     [
       TimexDatalinkClient::Protocol3::Eeprom::List.new(
         list_entry: "muffler bearings",
-        priority: 0
+        priority: nil
       ),
       TimexDatalinkClient::Protocol3::Eeprom::List.new(
         list_entry: "headlight fluid",
-        priority: 0
+        priority: nil
       )
     ]
   end

--- a/spec/lib/timex_datalink_client/protocol_4/eeprom/list_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/eeprom/list_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe TimexDatalinkClient::Protocol4::Eeprom::List do
   let(:list_entry) { "Muffler Bearings" }
-  let(:priority) { 0 }
+  let(:priority) { nil }
 
   let(:list) do
     described_class.new(
@@ -20,12 +20,42 @@ describe TimexDatalinkClient::Protocol4::Eeprom::List do
       0x00, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
     ]
 
-    context "when priority is 3" do
-      let(:priority) { 3 }
+    context "when priority is 1" do
+      let(:priority) { 1 }
 
       it_behaves_like "a length-prefixed packet", [
-        0x03, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
+        0x01, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
       ]
+    end
+
+    context "when priority is 5" do
+      let(:priority) { 5 }
+
+      it_behaves_like "a length-prefixed packet", [
+        0x05, 0x96, 0xf7, 0x3c, 0x95, 0xb3, 0x91, 0x8b, 0xa3, 0x6c, 0xd2, 0x05, 0x71, 0x3f
+      ]
+    end
+
+    context "when priority is 0" do
+      let(:priority) { 0 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Priority 0 is invalid!  Valid priorities are 1..5 or nil."
+        )
+      end
+    end
+
+    context "when priority is 6" do
+      let(:priority) { 6 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Priority 6 is invalid!  Valid priorities are 1..5 or nil."
+        )
+      end
     end
 
     context "when list_entry is \"Headlight Fluid with More than 31 Characters\"" do

--- a/spec/lib/timex_datalink_client/protocol_4/eeprom_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/eeprom_spec.rb
@@ -48,11 +48,11 @@ describe TimexDatalinkClient::Protocol4::Eeprom do
     [
       TimexDatalinkClient::Protocol4::Eeprom::List.new(
         list_entry: "muffler bearings",
-        priority: 0
+        priority: nil
       ),
       TimexDatalinkClient::Protocol4::Eeprom::List.new(
         list_entry: "headlight fluid",
-        priority: 0
+        priority: nil
       )
     ]
   end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -87,9 +87,10 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_9/timer.rb"
   ]
 
+  s.add_dependency "activemodel", "~> 7.0.4"
   s.add_dependency "crc", "~> 0.4.2"
-  s.add_dependency "rubyserial", "~> 0.6.0"
   s.add_dependency "mdb", "~> 0.5.0"
+  s.add_dependency "rubyserial", "~> 0.6.0"
 
   s.add_development_dependency "rspec", "~> 3.11.0"
   s.add_development_dependency "tzinfo", "~> 2.0.5"


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/225!

This PR adds validation for `Eeprom::List`'s `priority` value for protocols 1, 3, and 4!  It leverages the excellent [ActiveModel::Validations](https://guides.rubyonrails.org/active_record_validations.html) library to consume prior art for validations.

This PR also makes the "None" priority `nil`, as opposed to the previous `0`.  `0` was the literal data value for "None," but it is somewhat confusing because it can appear to have a higher priority than priority `1` ("Highest" in the Datalink software).