### PR TITLE
Add validation for Protocol9::Eeprom::Chrono's laps value

### DIFF
--- a/lib/timex_datalink_client/protocol_9/eeprom/chrono.rb
+++ b/lib/timex_datalink_client/protocol_9/eeprom/chrono.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/char_encoders"
 
 class TimexDatalinkClient
   class Protocol9
     class Eeprom
       class Chrono
+        include ActiveModel::Validations
         include Helpers::CharEncoders
 
         CHRONO_LABEL_LENGTH = 8
         CHRONO_INITIAL_SIZE = 14
 
         attr_accessor :label, :laps
+
+        validates :laps, inclusion: {
+          in: 2..50,
+          message: "value %{value} is invalid!  Valid laps values are 2..50."
+        }
 
         # Create a Chrono instance.
         #
@@ -27,6 +35,8 @@ class TimexDatalinkClient
         #
         # @return [Array<Integer>] Array of integers that represent bytes.
         def packet
+          validate!
+
           label_characters
         end
 

--- a/spec/lib/timex_datalink_client/protocol_9/eeprom/chrono_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/eeprom/chrono_spec.rb
@@ -59,6 +59,28 @@ describe TimexDatalinkClient::Protocol9::Eeprom::Chrono do
 
       it { should eq([0x24, 0x0c, 0x11, 0x1b, 0x18, 0x17, 0x18, 0x24]) }
     end
+
+    context "when laps is 1" do
+      let(:laps) { 1 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Laps value 1 is invalid!  Valid laps values are 2..50."
+        )
+      end
+    end
+
+    context "when laps is 51" do
+      let(:laps) { 51 }
+
+      it do
+        expect { packet }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Laps value 51 is invalid!  Valid laps values are 2..50."
+        )
+      end
+    end
   end
 
   describe "#chrono_bytesize", :crc do


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/230!

This PR adds validation for `Protocol9::Eeprom::Chrono`'s `laps` value.  Valid values are 2 to 50.