### PR TITLE
Move YARDoc ActiveModel::ValidationError @raises documentation to right methods

### DIFF
--- a/lib/timex_datalink_client/protocol_1/alarm.rb
+++ b/lib/timex_datalink_client/protocol_1/alarm.rb
@@ -32,7 +32,6 @@ class TimexDatalinkClient
       # @param message [String] Alarm message text.
       # @param month [Integer, nil] Month of alarm.
       # @param day [Integer, nil] Day of alarm.
-      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Alarm] Alarm instance.
       def initialize(number:, audible:, time:, message:, month: nil, day: nil)
         @number = number
@@ -45,6 +44,7 @@ class TimexDatalinkClient
 
       # Compile packets for an alarm.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
         validate!

--- a/lib/timex_datalink_client/protocol_1/eeprom/list.rb
+++ b/lib/timex_datalink_client/protocol_1/eeprom/list.rb
@@ -25,7 +25,6 @@ class TimexDatalinkClient
         #
         # @param list_entry [String] List entry text.
         # @param priority [Integer] List priority.
-        # @raise [ActiveModel::ValidationError] One or more model values are invalid.
         # @return [List] List instance.
         def initialize(list_entry:, priority:)
           @list_entry = list_entry
@@ -34,6 +33,7 @@ class TimexDatalinkClient
 
         # Compile a packet for a list.
         #
+        # @raise [ActiveModel::ValidationError] One or more model values are invalid.
         # @return [Array<Integer>] Array of integers that represent bytes.
         def packet
           validate!

--- a/lib/timex_datalink_client/protocol_3/alarm.rb
+++ b/lib/timex_datalink_client/protocol_3/alarm.rb
@@ -27,7 +27,6 @@ class TimexDatalinkClient
       # @param audible [Boolean] Toggle alarm sounds.
       # @param time [::Time] Time of alarm.
       # @param message [String] Alarm message text.
-      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Alarm] Alarm instance.
       def initialize(number:, audible:, time:, message:)
         @number = number
@@ -38,6 +37,7 @@ class TimexDatalinkClient
 
       # Compile packets for an alarm.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
         validate!

--- a/lib/timex_datalink_client/protocol_3/eeprom/list.rb
+++ b/lib/timex_datalink_client/protocol_3/eeprom/list.rb
@@ -25,7 +25,6 @@ class TimexDatalinkClient
         #
         # @param list_entry [String] List entry text.
         # @param priority [Integer, nil] List priority.
-        # @raise [ActiveModel::ValidationError] One or more model values are invalid.
         # @return [List] List instance.
         def initialize(list_entry:, priority:)
           @list_entry = list_entry
@@ -34,6 +33,7 @@ class TimexDatalinkClient
 
         # Compile a packet for a list.
         #
+        # @raise [ActiveModel::ValidationError] One or more model values are invalid.
         # @return [Array<Integer>] Array of integers that represent bytes.
         def packet
           validate!

--- a/lib/timex_datalink_client/protocol_4/alarm.rb
+++ b/lib/timex_datalink_client/protocol_4/alarm.rb
@@ -27,7 +27,6 @@ class TimexDatalinkClient
       # @param audible [Boolean] Toggle alarm sounds.
       # @param time [::Time] Time of alarm.
       # @param message [String] Alarm message text.
-      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Alarm] Alarm instance.
       def initialize(number:, audible:, time:, message:)
         @number = number
@@ -38,6 +37,7 @@ class TimexDatalinkClient
 
       # Compile packets for an alarm.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
         validate!

--- a/lib/timex_datalink_client/protocol_4/eeprom/list.rb
+++ b/lib/timex_datalink_client/protocol_4/eeprom/list.rb
@@ -33,6 +33,7 @@ class TimexDatalinkClient
 
         # Compile a packet for a list.
         #
+        # @raise [ActiveModel::ValidationError] One or more model values are invalid.
         # @return [Array<Integer>] Array of integers that represent bytes.
         def packet
           validate!

--- a/lib/timex_datalink_client/protocol_9/alarm.rb
+++ b/lib/timex_datalink_client/protocol_9/alarm.rb
@@ -29,7 +29,6 @@ class TimexDatalinkClient
       # @param message [String] Alarm message text.
       # @param month [Integer, nil] Month of alarm.
       # @param day [Integer, nil] Day of alarm.
-      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Alarm] Alarm instance.
       def initialize(number:, audible:, time:, message:, month: nil, day: nil)
         @number = number
@@ -42,6 +41,7 @@ class TimexDatalinkClient
 
       # Compile packets for an alarm.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
         validate!

--- a/lib/timex_datalink_client/protocol_9/eeprom/chrono.rb
+++ b/lib/timex_datalink_client/protocol_9/eeprom/chrono.rb
@@ -33,6 +33,7 @@ class TimexDatalinkClient
 
         # Compile a packet for a chrono.
         #
+        # @raise [ActiveModel::ValidationError] One or more model values are invalid.
         # @return [Array<Integer>] Array of integers that represent bytes.
         def packet
           validate!


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/233!

This PR moves some YARDoc @raises to the right locations :+1: 