### PR TITLE
Add validation for Time's zone parameter for protocols 1, 3, 4, and 9

### DIFF
--- a/lib/timex_datalink_client/protocol_1/time.rb
+++ b/lib/timex_datalink_client/protocol_1/time.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol1
     class Time
+      include ActiveModel::Validations
       prepend Helpers::CrcPacketsWrapper
 
       CPACKET_TIME = [0x30]
 
       attr_accessor :zone, :is_24h, :time
+
+      validates :zone, inclusion: {
+        in: 1..2,
+        message: "%{value} is invalid!  Valid zones are 1..2."
+      }
 
       # Create a Time instance.
       #
@@ -25,8 +33,11 @@ class TimexDatalinkClient
 
       # Compile packets for a time.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [
           [
             CPACKET_TIME,

--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/char_encoders"
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol3
     class Time
+      include ActiveModel::Validations
       include Helpers::CharEncoders
       prepend Helpers::CrcPacketsWrapper
 
@@ -19,6 +22,11 @@ class TimexDatalinkClient
         "%_d.%m.%y" => 5,
         "%y.%m.%d" => 6
       }.freeze
+
+      validates :zone, inclusion: {
+        in: 1..2,
+        message: "%{value} is invalid!  Valid zones are 1..2."
+      }
 
       attr_accessor :zone, :is_24h, :date_format, :time
 
@@ -41,8 +49,11 @@ class TimexDatalinkClient
 
       # Compile packets for a time.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [
           [
             CPACKET_TIME,

--- a/lib/timex_datalink_client/protocol_4/time.rb
+++ b/lib/timex_datalink_client/protocol_4/time.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/char_encoders"
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol4
     class Time
+      include ActiveModel::Validations
       include Helpers::CharEncoders
       prepend Helpers::CrcPacketsWrapper
 
@@ -19,6 +22,11 @@ class TimexDatalinkClient
         "%_d.%m.%y" => 5,
         "%y.%m.%d" => 6
       }.freeze
+
+      validates :zone, inclusion: {
+        in: 1..2,
+        message: "%{value} is invalid!  Valid zones are 1..2."
+      }
 
       attr_accessor :zone, :is_24h, :date_format, :time
 
@@ -41,8 +49,11 @@ class TimexDatalinkClient
 
       # Compile packets for a time.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [
           [
             CPACKET_TIME,

--- a/lib/timex_datalink_client/protocol_9/time.rb
+++ b/lib/timex_datalink_client/protocol_9/time.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol9
     class Time
+      include ActiveModel::Validations
       prepend Helpers::CrcPacketsWrapper
 
       CPACKET_TIME = [0x30]
 
       attr_accessor :zone, :is_24h, :time
+
+      validates :zone, inclusion: {
+        in: 1..2,
+        message: "%{value} is invalid!  Valid zones are 1..2."
+      }
 
       # Create a Time instance.
       #
@@ -25,8 +33,11 @@ class TimexDatalinkClient
 
       # Compile packets for a time.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [
           [
             CPACKET_TIME,

--- a/spec/lib/timex_datalink_client/protocol_1/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/time_spec.rb
@@ -30,6 +30,28 @@ describe TimexDatalinkClient::Protocol1::Time do
       ]
     end
 
+    context "when zone is 0" do
+      let(:zone) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 0 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
+    context "when zone is 3" do
+      let(:zone) { 3 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 3 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
     context "when is_24h is true" do
       let(:is_24h) { true }
 

--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -37,6 +37,28 @@ describe TimexDatalinkClient::Protocol3::Time do
       ]
     end
 
+    context "when zone is 0" do
+      let(:zone) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 0 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
+    context "when zone is 3" do
+      let(:zone) { 3 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 3 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
     context "when is_24h is true" do
       let(:is_24h) { true }
 

--- a/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
@@ -37,6 +37,28 @@ describe TimexDatalinkClient::Protocol4::Time do
       ]
     end
 
+    context "when zone is 0" do
+      let(:zone) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 0 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
+    context "when zone is 3" do
+      let(:zone) { 3 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 3 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
     context "when is_24h is true" do
       let(:is_24h) { true }
 

--- a/spec/lib/timex_datalink_client/protocol_9/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/time_spec.rb
@@ -30,6 +30,28 @@ describe TimexDatalinkClient::Protocol9::Time do
       ]
     end
 
+    context "when zone is 0" do
+      let(:zone) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 0 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
+    context "when zone is 3" do
+      let(:zone) { 3 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 3 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
     context "when is_24h is true" do
       let(:is_24h) { true }
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/228!

Adds validation for Time's zone parameter on protocols 1, 3, 4, and 9.  The only valid values for all parameters are 1 and 2.