### PR TITLE
Add validation for TimeName's zone parameter for protocols 1 and 9

### DIFF
--- a/lib/timex_datalink_client/protocol_1/time_name.rb
+++ b/lib/timex_datalink_client/protocol_1/time_name.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/char_encoders"
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol1
     class TimeName
+      include ActiveModel::Validations
       include Helpers::CharEncoders
       prepend Helpers::CrcPacketsWrapper
 
       CPACKET_NAME = [0x31]
 
       attr_accessor :zone, :name
+
+      validates :zone, inclusion: {
+        in: 1..2,
+        message: "%{value} is invalid!  Valid zones are 1..2."
+      }
 
       # Create a TimeName instance.
       #
@@ -25,8 +33,11 @@ class TimexDatalinkClient
 
       # Compile packets for a time name.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [
           [
             CPACKET_NAME,

--- a/lib/timex_datalink_client/protocol_9/time_name.rb
+++ b/lib/timex_datalink_client/protocol_9/time_name.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/char_encoders"
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol9
     class TimeName
+      include ActiveModel::Validations
       include Helpers::CharEncoders
       prepend Helpers::CrcPacketsWrapper
 
       CPACKET_NAME = [0x31]
 
       attr_accessor :zone, :name
+
+      validates :zone, inclusion: {
+        in: 1..2,
+        message: "%{value} is invalid!  Valid zones are 1..2."
+      }
 
       # Create a TimeName instance.
       #
@@ -25,8 +33,11 @@ class TimexDatalinkClient
 
       # Compile packets for a time name.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [
           [
             CPACKET_NAME,

--- a/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
@@ -28,6 +28,28 @@ describe TimexDatalinkClient::Protocol1::TimeName do
       ]
     end
 
+    context "when zone is 0" do
+      let(:zone) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 0 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
+    context "when zone is 3" do
+      let(:zone) { 3 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 3 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
     context "when name is \"1\"" do
       let(:name) { "1" }
 

--- a/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
@@ -28,6 +28,28 @@ describe TimexDatalinkClient::Protocol9::TimeName do
       ]
     end
 
+    context "when zone is 0" do
+      let(:zone) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 0 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
+    context "when zone is 3" do
+      let(:zone) { 3 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Zone 3 is invalid!  Valid zones are 1..2."
+        )
+      end
+    end
+
     context "when name is \"1\"" do
       let(:name) { "1" }
 


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/229!

This PR adds validation for TimeName's zone parameter for protocols 1 and 9 :sparkles: 