### PR TITLE
Add validation for Time's date_format value for protocols 3 and 4

### DIFF
--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -28,6 +28,11 @@ class TimexDatalinkClient
         message: "%{value} is invalid!  Valid zones are 1..2."
       }
 
+      validates :date_format, inclusion: {
+        in: DATE_FORMAT_MAP.keys,
+        message: "%{value} is invalid!  Valid date formats are #{DATE_FORMAT_MAP.keys}."
+      }
+
       attr_accessor :zone, :is_24h, :date_format, :time
 
       # Create a Time instance.

--- a/lib/timex_datalink_client/protocol_4/time.rb
+++ b/lib/timex_datalink_client/protocol_4/time.rb
@@ -28,6 +28,11 @@ class TimexDatalinkClient
         message: "%{value} is invalid!  Valid zones are 1..2."
       }
 
+      validates :date_format, inclusion: {
+        in: DATE_FORMAT_MAP.keys,
+        message: "%{value} is invalid!  Valid date formats are #{DATE_FORMAT_MAP.keys}."
+      }
+
       attr_accessor :zone, :is_24h, :date_format, :time
 
       # Create a Time instance.

--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -107,6 +107,18 @@ describe TimexDatalinkClient::Protocol3::Time do
       ]
     end
 
+    context "when date_format is \"%y\"" do
+      let(:date_format) { "%y" }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Date format %y is invalid!  Valid date formats are [\"%_m-%d-%y\", \"%_d-%m-%y\"," \
+          " \"%y-%m-%d\", \"%_m.%d.%y\", \"%_d.%m.%y\", \"%y.%m.%d\"]."
+        )
+      end
+    end
+
     context "when time is 1997-09-19 19:36:55 NZDT" do
       let(:tzinfo) { TZInfo::Timezone.get("Pacific/Auckland") }
       let(:time) { tzinfo.local_time(1997, 9, 19, 19, 36, 55) }

--- a/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
@@ -107,6 +107,18 @@ describe TimexDatalinkClient::Protocol4::Time do
       ]
     end
 
+    context "when date_format is \"%y\"" do
+      let(:date_format) { "%y" }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Date format %y is invalid!  Valid date formats are [\"%_m-%d-%y\", \"%_d-%m-%y\"," \
+          " \"%y-%m-%d\", \"%_m.%d.%y\", \"%_d.%m.%y\", \"%y.%m.%d\"]."
+        )
+      end
+    end
+
     context "when time is 1997-09-19 19:36:55 NZDT" do
       let(:tzinfo) { TZInfo::Timezone.get("Pacific/Auckland") }
       let(:time) { tzinfo.local_time(1997, 9, 19, 19, 36, 55) }


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/237!

This PR adds validations for Time's date_format value for protocols 3 and 4 :sparkles: 