### PR TITLE
Add validation for Alarm month and day for protocols 1 and 9

### DIFF
--- a/lib/timex_datalink_client/protocol_1/alarm.rb
+++ b/lib/timex_datalink_client/protocol_1/alarm.rb
@@ -17,6 +17,21 @@ class TimexDatalinkClient
 
       ALARM_SILENT_START_INDEX = 0x61
 
+      VALID_DAYS_IN_MONTH = {
+        1 => 1..31,
+        2 => 1..29,
+        3 => 1..31,
+        4 => 1..30,
+        5 => 1..31,
+        6 => 1..30,
+        7 => 1..31,
+        8 => 1..31,
+        9 => 1..30,
+        10 => 1..31,
+        11 => 1..30,
+        12 => 1..31
+      }.freeze
+
       attr_accessor :number, :audible, :time, :message, :month, :day
 
       validates :number, inclusion: {
@@ -31,9 +46,19 @@ class TimexDatalinkClient
       }
 
       validates :day, inclusion: {
+        if: ->(alarm) { alarm.month.nil? },
         in: 1..31,
         allow_nil: true,
         message: "%{value} is invalid!  Valid days are 1..31 and nil."
+      }
+
+      validates :day, inclusion: {
+        if: ->(alarm) { alarm.day && alarm.month },
+        in: ->(alarm) { VALID_DAYS_IN_MONTH[alarm.month] },
+        message: ->(alarm, _attributes) do
+          "#{alarm.day} is invalid for month #{alarm.month}!  " \
+          "Valid days are #{VALID_DAYS_IN_MONTH[alarm.month]} and nil when month is #{alarm.month}."
+        end
       }
 
       # Create an Alarm instance.

--- a/lib/timex_datalink_client/protocol_1/alarm.rb
+++ b/lib/timex_datalink_client/protocol_1/alarm.rb
@@ -24,6 +24,18 @@ class TimexDatalinkClient
         message: "value %{value} is invalid!  Valid number values are 1..5."
       }
 
+      validates :month, inclusion: {
+        in: 1..12,
+        allow_nil: true,
+        message: "%{value} is invalid!  Valid months are 1..12 and nil."
+      }
+
+      validates :day, inclusion: {
+        in: 1..31,
+        allow_nil: true,
+        message: "%{value} is invalid!  Valid days are 1..31 and nil."
+      }
+
       # Create an Alarm instance.
       #
       # @param number [Integer] Alarm number (from 1 to 5).

--- a/lib/timex_datalink_client/protocol_9/alarm.rb
+++ b/lib/timex_datalink_client/protocol_9/alarm.rb
@@ -14,11 +14,48 @@ class TimexDatalinkClient
 
       CPACKET_ALARM = [0x50]
 
+      VALID_DAYS_IN_MONTH = {
+        1 => 1..31,
+        2 => 1..29,
+        3 => 1..31,
+        4 => 1..30,
+        5 => 1..31,
+        6 => 1..30,
+        7 => 1..31,
+        8 => 1..31,
+        9 => 1..30,
+        10 => 1..31,
+        11 => 1..30,
+        12 => 1..31
+      }.freeze
+
       attr_accessor :number, :audible, :time, :message, :month, :day
 
       validates :number, inclusion: {
         in: 1..10,
         message: "value %{value} is invalid!  Valid number values are 1..10."
+      }
+
+      validates :month, inclusion: {
+        in: 1..12,
+        allow_nil: true,
+        message: "%{value} is invalid!  Valid months are 1..12 and nil."
+      }
+
+      validates :day, inclusion: {
+        if: ->(alarm) { alarm.month.nil? },
+        in: 1..31,
+        allow_nil: true,
+        message: "%{value} is invalid!  Valid days are 1..31 and nil."
+      }
+
+      validates :day, inclusion: {
+        if: ->(alarm) { alarm.day && alarm.month },
+        in: ->(alarm) { VALID_DAYS_IN_MONTH[alarm.month] },
+        message: ->(alarm, _attributes) do
+          "#{alarm.day} is invalid for month #{alarm.month}!  " \
+          "Valid days are #{VALID_DAYS_IN_MONTH[alarm.month]} and nil when month is #{alarm.month}."
+        end
       }
 
       # Create an Alarm instance.

--- a/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
@@ -104,13 +104,24 @@ describe TimexDatalinkClient::Protocol1::Alarm do
       ]
     end
 
-    context "when month is 12" do
-      let(:month) { 12 }
+    context "when month is 2" do
+      let(:month) { 2 }
 
       it_behaves_like "CRC-wrapped packets", [
-        [0x50, 0x01, 0x00, 0x00, 0x0c, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x00],
+        [0x50, 0x01, 0x00, 0x00, 0x02, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x00],
         [0x70, 0x00, 0x62, 0x00]
       ]
+
+      context "when day is 35" do
+        let(:day) { 35 }
+
+        it do
+          expect { packets }.to raise_error(
+            ActiveModel::ValidationError,
+            "Validation failed: Day 35 is invalid for month 2!  Valid days are 1..29 and nil when month is 2."
+          )
+        end
+      end
     end
 
     context "when month is 0" do

--- a/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
@@ -176,6 +176,5 @@ describe TimexDatalinkClient::Protocol1::Alarm do
         )
       end
     end
-
   end
 end

--- a/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
@@ -112,13 +112,13 @@ describe TimexDatalinkClient::Protocol1::Alarm do
         [0x70, 0x00, 0x62, 0x00]
       ]
 
-      context "when day is 35" do
-        let(:day) { 35 }
+      context "when day is 30" do
+        let(:day) { 30 }
 
         it do
           expect { packets }.to raise_error(
             ActiveModel::ValidationError,
-            "Validation failed: Day 35 is invalid for month 2!  Valid days are 1..29 and nil when month is 2."
+            "Validation failed: Day 30 is invalid for month 2!  Valid days are 1..29 and nil when month is 2."
           )
         end
       end

--- a/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/alarm_spec.rb
@@ -113,6 +113,28 @@ describe TimexDatalinkClient::Protocol1::Alarm do
       ]
     end
 
+    context "when month is 0" do
+      let(:month) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Month 0 is invalid!  Valid months are 1..12 and nil."
+        )
+      end
+    end
+
+    context "when month is 13" do
+      let(:month) { 13 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Month 13 is invalid!  Valid months are 1..12 and nil."
+        )
+      end
+    end
+
     context "when day is 25" do
       let(:day) { 25 }
 
@@ -121,5 +143,28 @@ describe TimexDatalinkClient::Protocol1::Alarm do
         [0x70, 0x00, 0x62, 0x00]
       ]
     end
+
+    context "when day is 0" do
+      let(:day) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Day 0 is invalid!  Valid days are 1..31 and nil."
+        )
+      end
+    end
+
+    context "when day is 32" do
+      let(:day) { 32 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Day 32 is invalid!  Valid days are 1..31 and nil."
+        )
+      end
+    end
+
   end
 end

--- a/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
@@ -119,15 +119,48 @@ describe TimexDatalinkClient::Protocol9::Alarm do
       ]
     end
 
-    context "when month is 12" do
-      let(:month) { 12 }
+    context "when month is 2" do
+      let(:month) { 2 }
 
       it_behaves_like "CRC-wrapped packets", [
         [
-          0x50, 0x01, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x24, 0x24, 0x24,
+          0x50, 0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0x0a, 0x15, 0x0a, 0x1b, 0x16, 0x24, 0x01, 0x24, 0x24, 0x24, 0x24,
           0x24, 0x24, 0x24, 0x24, 0x24
         ]
       ]
+
+      context "when day is 35" do
+        let(:day) { 35 }
+
+        it do
+          expect { packets }.to raise_error(
+            ActiveModel::ValidationError,
+            "Validation failed: Day 35 is invalid for month 2!  Valid days are 1..29 and nil when month is 2."
+          )
+        end
+      end
+    end
+
+    context "when month is 0" do
+      let(:month) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Month 0 is invalid!  Valid months are 1..12 and nil."
+        )
+      end
+    end
+
+    context "when month is 13" do
+      let(:month) { 13 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Month 13 is invalid!  Valid months are 1..12 and nil."
+        )
+      end
     end
 
     context "when day is 25" do

--- a/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
@@ -129,13 +129,13 @@ describe TimexDatalinkClient::Protocol9::Alarm do
         ]
       ]
 
-      context "when day is 35" do
-        let(:day) { 35 }
+      context "when day is 30" do
+        let(:day) { 30 }
 
         it do
           expect { packets }.to raise_error(
             ActiveModel::ValidationError,
-            "Validation failed: Day 35 is invalid for month 2!  Valid days are 1..29 and nil when month is 2."
+            "Validation failed: Day 30 is invalid for month 2!  Valid days are 1..29 and nil when month is 2."
           )
         end
       end

--- a/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/alarm_spec.rb
@@ -173,5 +173,27 @@ describe TimexDatalinkClient::Protocol9::Alarm do
         ]
       ]
     end
+
+    context "when day is 0" do
+      let(:day) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Day 0 is invalid!  Valid days are 1..31 and nil."
+        )
+      end
+    end
+
+    context "when day is 32" do
+      let(:day) { 32 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Day 32 is invalid!  Valid days are 1..31 and nil."
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/239!

Adds day and month validation for protocol 1 and 9 Alarm model classes!  Protocols 1 and 9 are the only protocols that have day and month values for the alarms.