### PR TITLE
Add LsbMsbFormatter for protocol 7

### DIFF
--- a/lib/timex_datalink_client/helpers/lsb_msb_formatter.rb
+++ b/lib/timex_datalink_client/helpers/lsb_msb_formatter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TimexDatalinkClient
+  class Helpers
+    module LsbMsbFormatter
+      def lsb_msb_format_for(value)
+        value.divmod(256).reverse
+      end
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_7/eeprom/calendar.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/calendar.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "timex_datalink_client/helpers/four_byte_formatter"
+require "timex_datalink_client/helpers/lsb_msb_formatter"
 
 class TimexDatalinkClient
   class Protocol7
     class Eeprom
       class Calendar
         include Helpers::FourByteFormatter
+        include Helpers::LsbMsbFormatter
 
         DAY_START_TIME = Time.new(2000)
         DAY_SECONDS = 86400
@@ -48,7 +50,7 @@ class TimexDatalinkClient
         private
 
         def events_count
-          events.count.divmod(256).reverse
+          lsb_msb_format_for(events.count)
         end
 
         def event_packets
@@ -57,7 +59,7 @@ class TimexDatalinkClient
 
           [].tap do |event_packets|
             events.each_with_index do |event, event_index|
-              event_bytes_formatted = event_bytes.divmod(256).reverse
+              event_bytes_formatted = lsb_msb_format_for(event_bytes)
               event_time_formatted = event.time_formatted(time)
 
               event_packets << [event_time_formatted, event_bytes_formatted]
@@ -77,13 +79,13 @@ class TimexDatalinkClient
           since_start_time_seconds = time - DAY_START_TIME
           since_start_time_days = since_start_time_seconds.to_i / DAY_SECONDS
 
-          since_start_time_days.divmod(256).reverse
+          lsb_msb_format_for(since_start_time_days)
         end
 
         def time_formatted
           five_mintes = (time.hour * 60 + time.min) / 5
 
-          five_mintes.divmod(256).reverse
+          lsb_msb_format_for(five_mintes)
         end
       end
     end

--- a/lib/timex_datalink_client/protocol_7/eeprom/calendar/event.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/calendar/event.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require "timex_datalink_client/helpers/lsb_msb_formatter"
+
 class TimexDatalinkClient
   class Protocol7
     class Eeprom
       class Calendar
         class Event
+          include Helpers::LsbMsbFormatter
+
           FIVE_MINUTES_SECONDS = 300
 
           attr_accessor :time, :phrase
@@ -24,7 +28,7 @@ class TimexDatalinkClient
             seconds = (time - device_time_midnight).to_i
             five_minutes = seconds / FIVE_MINUTES_SECONDS
 
-            five_minutes.divmod(256).reverse
+            lsb_msb_format_for(five_minutes)
           end
         end
       end

--- a/lib/timex_datalink_client/protocol_7/eeprom/games.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/games.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "timex_datalink_client/helpers/four_byte_formatter"
+require "timex_datalink_client/helpers/lsb_msb_formatter"
 
 class TimexDatalinkClient
   class Protocol7
     class Eeprom
       class Games
         include Helpers::FourByteFormatter
+        include Helpers::LsbMsbFormatter
 
         COUNTDOWN_TIMER_SECONDS_DEFAULT = 60
 
@@ -85,11 +87,11 @@ class TimexDatalinkClient
             game ? 1 << game_index : 0
           end
 
-          bitmask.divmod(256).reverse
+          lsb_msb_format_for(bitmask)
         end
 
         def countdown_timer_time
-          (countdown_timer_seconds * 10).divmod(256).reverse
+          lsb_msb_format_for(countdown_timer_seconds * 10)
         end
 
         def sounds

--- a/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "timex_datalink_client/helpers/four_byte_formatter"
+require "timex_datalink_client/helpers/lsb_msb_formatter"
 
 class TimexDatalinkClient
   class Protocol7
     class Eeprom
       class Speech
         include Helpers::FourByteFormatter
+        include Helpers::LsbMsbFormatter
 
         NICKNAME_LENGTH_WITHOUT_DEVICE = 10
         NICKNAME_LENGTH_WITH_DEVICE = 14
@@ -123,7 +125,7 @@ class TimexDatalinkClient
         def header
           all_values = [header_value_1, header_value_2, header_value_3] + header_values_4 + header_values_5
 
-          all_values.flat_map { |value| value.divmod(256).reverse }
+          all_values.flat_map { |value| lsb_msb_format_for(value) }
         end
 
         def header_value_1

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/helpers/crc_packets_wrapper.rb",
     "lib/timex_datalink_client/helpers/four_byte_formatter.rb",
     "lib/timex_datalink_client/helpers/length_packet_wrapper.rb",
+    "lib/timex_datalink_client/helpers/lsb_msb_formatter.rb",
 
     "lib/timex_datalink_client/protocol_1/alarm.rb",
     "lib/timex_datalink_client/protocol_1/eeprom.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/241!

This PR adds a LsbMsbFormatter helper with `lsb_msb_format_for`.  This moves all the `.divmod(256).reverse` calls into a single helper method.