### PR TITLE
Add gemspec CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,14 @@ jobs:
         with:
           bundler-cache: true
       - run: bundle exec yard-junk
+
+  gemspec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: gem build timex_datalink_client.gemspec
+      - run: gem install timex_datalink_client-*.gem
+      - run: ruby -e 'require "timex_datalink_client"'

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_3/eeprom/appointment.rb",
     "lib/timex_datalink_client/protocol_3/eeprom/list.rb",
     "lib/timex_datalink_client/protocol_3/eeprom/phone_number.rb",
-    # "lib/timex_datalink_client/protocol_3/end.rb",
+    "lib/timex_datalink_client/protocol_3/end.rb",
     "lib/timex_datalink_client/protocol_3/sound_options.rb",
     "lib/timex_datalink_client/protocol_3/sound_theme.rb",
     "lib/timex_datalink_client/protocol_3/start.rb",

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_3/eeprom/appointment.rb",
     "lib/timex_datalink_client/protocol_3/eeprom/list.rb",
     "lib/timex_datalink_client/protocol_3/eeprom/phone_number.rb",
-    "lib/timex_datalink_client/protocol_3/end.rb",
+    # "lib/timex_datalink_client/protocol_3/end.rb",
     "lib/timex_datalink_client/protocol_3/sound_options.rb",
     "lib/timex_datalink_client/protocol_3/sound_theme.rb",
     "lib/timex_datalink_client/protocol_3/start.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/247!

This PR adds a CI job to do a quick check on the gemspec.  This lib loads everything by requiring `timex_datalink_client`, so simply doing this require is enough to ensure that everything can load from the gem.

This new CI job...

- builds a gem from the gemspec file
- installs the gem built from the gemspec file
- requires `timex_datalink_client`

If something breaks, requiring `timex_datalink_client` will raise an exception and fail the CI, like so:

![image](https://user-images.githubusercontent.com/820984/209484067-bc419ef5-db9e-469b-b1de-196369d801b5.png)