### PR TITLE
Use real minutes for Eeprom appointment notifications

### DIFF
--- a/docs/timex_datalink_protocol_1.md
+++ b/docs/timex_datalink_protocol_1.md
@@ -30,9 +30,22 @@ appointments = [
 
 TimexDatalinkClient::Protocol1::Eeprom.new(
   appointments: appointments,
-  appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
+  appointment_notification_minutes: 15
 )
 ```
+
+Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent `Appointment` `appointment_notification_minutes` values:
+
+|Timex Datalink Watch pre-notification beep value|`Appointment` `appointment_notification_minutes` value|
+|---|---|
+|No beep|`nil`|
+|At time of appointments|`0`|
+|5 minutes before appointments|`5`|
+|10 minutes before appointments|`10`|
+|15 minutes before appointments|`15`|
+|20 minutes before appointments|`20`|
+|25 minutes before appointments|`25`|
+|30 minutes before appointments|`30`|
 
 ## Anniversaries
 
@@ -299,7 +312,7 @@ models = [
     anniversaries: anniversaries,
     lists: lists,
     phone_numbers: phone_numbers,
-    appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
+    appointment_notification_minutes: 15
   ),
 
   TimexDatalinkClient::Protocol1::End.new

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -27,9 +27,22 @@ appointments = [
 
 TimexDatalinkClient::Protocol3::Eeprom.new(
   appointments: appointments,
-  appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
+  appointment_notification_minutes: 15
 )
 ```
+
+Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent `Appointment` `appointment_notification_minutes` values:
+
+|Timex Datalink Watch pre-notification beep value|`Appointment` `appointment_notification_minutes` value|
+|---|---|
+|No beep|`nil`|
+|At time of appointments|`0`|
+|5 minutes before appointments|`5`|
+|10 minutes before appointments|`10`|
+|15 minutes before appointments|`15`|
+|20 minutes before appointments|`20`|
+|25 minutes before appointments|`25`|
+|30 minutes before appointments|`30`|
 
 ## Anniversaries
 
@@ -323,7 +336,7 @@ models = [
     anniversaries: anniversaries,
     lists: lists,
     phone_numbers: phone_numbers,
-    appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
+    appointment_notification_minutes: 15
   ),
 
   TimexDatalinkClient::Protocol3::SoundTheme.new(spc_file: "DEFHIGH.SPC"),

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -27,9 +27,22 @@ appointments = [
 
 TimexDatalinkClient::Protocol4::Eeprom.new(
   appointments: appointments,
-  appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
+  appointment_notification_minutes: 15
 )
 ```
+
+Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent `Appointment` `appointment_notification_minutes` values:
+
+|Timex Datalink Watch pre-notification beep value|`Appointment` `appointment_notification_minutes` value|
+|---|---|
+|No beep|`nil`|
+|At time of appointments|`0`|
+|5 minutes before appointments|`5`|
+|10 minutes before appointments|`10`|
+|15 minutes before appointments|`15`|
+|20 minutes before appointments|`20`|
+|25 minutes before appointments|`25`|
+|30 minutes before appointments|`30`|
 
 ## Anniversaries
 
@@ -323,7 +336,7 @@ models = [
     anniversaries: anniversaries,
     lists: lists,
     phone_numbers: phone_numbers,
-    appointment_notification: 3  # In 5 minute intervals.  255 for no notification.
+    appointment_notification_minutes: 15
   ),
 
   TimexDatalinkClient::Protocol4::SoundTheme.new(spc_file: "DEFHIGH.SPC"),

--- a/lib/timex_datalink_client/protocol_1/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_1/eeprom.rb
@@ -50,6 +50,7 @@ class TimexDatalinkClient
 
       # Compile packets for EEPROM data.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
         validate!

--- a/lib/timex_datalink_client/protocol_1/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_1/eeprom.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/cpacket_paginator"
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol1
     class Eeprom
+      include ActiveModel::Validations
       include Helpers::CpacketPaginator
       prepend Helpers::CrcPacketsWrapper
 
@@ -16,8 +19,16 @@ class TimexDatalinkClient
       CPACKET_DATA_LENGTH = 27
       START_INDEX = 14
       APPOINTMENT_NO_NOTIFICATION = 0xff
+      APPOINTMENT_NOTIFICATION_VALID_MINUTES = (0..30).step(5)
 
-      attr_accessor :appointments, :anniversaries, :phone_numbers, :lists, :appointment_notification
+      attr_accessor :appointments, :anniversaries, :phone_numbers, :lists, :appointment_notification_minutes
+
+      validates :appointment_notification_minutes, inclusion: {
+        in: APPOINTMENT_NOTIFICATION_VALID_MINUTES,
+        allow_nil: true,
+        message: "value %{value} is invalid!  Valid appointment notification minutes values are" \
+          " #{APPOINTMENT_NOTIFICATION_VALID_MINUTES.to_a} or nil."
+      }
 
       # Create an Eeprom instance.
       #
@@ -25,21 +36,24 @@ class TimexDatalinkClient
       # @param anniversaries [Array<Anniversary>] Anniversaries to be added to EEPROM data.
       # @param phone_numbers [Array<PhoneNumber>] Phone numbers to be added to EEPROM data.
       # @param lists [Array<List>] Lists to be added to EEPROM data.
-      # @param appointment_notification [Integer] Appointment notification (intervals of 15 minutes, 255 for no
-      #   notification)
+      # @param appointment_notification_minutes [Integer, nil] Appointment notification in minutes.
       # @return [Eeprom] Eeprom instance.
-      def initialize(appointments: [], anniversaries: [], phone_numbers: [], lists: [], appointment_notification: APPOINTMENT_NO_NOTIFICATION)
+      def initialize(
+        appointments: [], anniversaries: [], phone_numbers: [], lists: [], appointment_notification_minutes: nil
+      )
         @appointments = appointments
         @anniversaries = anniversaries
         @phone_numbers = phone_numbers
         @lists = lists
-        @appointment_notification = appointment_notification
+        @appointment_notification_minutes = appointment_notification_minutes
       end
 
       # Compile packets for EEPROM data.
       #
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [header] + payloads + [CPACKET_END]
       end
 
@@ -57,7 +71,7 @@ class TimexDatalinkClient
           items_indexes,
           items_lengths,
           earliest_appointment_year,
-          appointment_notification,
+          appointment_notification_minutes_value,
           all_packets
         ].flatten
       end
@@ -94,6 +108,12 @@ class TimexDatalinkClient
         return 0 unless earliest_appointment
 
         earliest_appointment.time.year % 100
+      end
+
+      def appointment_notification_minutes_value
+        return APPOINTMENT_NO_NOTIFICATION unless appointment_notification_minutes
+
+        appointment_notification_minutes / 5
       end
     end
   end

--- a/lib/timex_datalink_client/protocol_3/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_3/eeprom.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/cpacket_paginator"
 require "timex_datalink_client/helpers/crc_packets_wrapper"
 
 class TimexDatalinkClient
   class Protocol3
     class Eeprom
+      include ActiveModel::Validations
       include Helpers::CpacketPaginator
       prepend Helpers::CrcPacketsWrapper
 
@@ -17,8 +20,16 @@ class TimexDatalinkClient
       CPACKET_DATA_LENGTH = 32
       START_ADDRESS = 0x0236
       APPOINTMENT_NO_NOTIFICATION = 0xff
+      APPOINTMENT_NOTIFICATION_VALID_MINUTES = (0..30).step(5)
 
-      attr_accessor :appointments, :anniversaries, :phone_numbers, :lists, :appointment_notification
+      attr_accessor :appointments, :anniversaries, :phone_numbers, :lists, :appointment_notification_minutes
+
+      validates :appointment_notification_minutes, inclusion: {
+        in: APPOINTMENT_NOTIFICATION_VALID_MINUTES,
+        allow_nil: true,
+        message: "value %{value} is invalid!  Valid appointment notification minutes values are" \
+          " #{APPOINTMENT_NOTIFICATION_VALID_MINUTES.to_a} or nil."
+      }
 
       # Create an Eeprom instance.
       #
@@ -26,21 +37,24 @@ class TimexDatalinkClient
       # @param anniversaries [Array<Anniversary>] Anniversaries to be added to EEPROM data.
       # @param phone_numbers [Array<PhoneNumber>] Phone numbers to be added to EEPROM data.
       # @param lists [Array<List>] Lists to be added to EEPROM data.
-      # @param appointment_notification [Integer] Appointment notification (intervals of 15 minutes, 255 for no
-      #   notification)
+      # @param appointment_notification_minutes [Integer, nil] Appointment notification in minutes.
       # @return [Eeprom] Eeprom instance.
-      def initialize(appointments: [], anniversaries: [], phone_numbers: [], lists: [], appointment_notification: APPOINTMENT_NO_NOTIFICATION)
+      def initialize(
+        appointments: [], anniversaries: [], phone_numbers: [], lists: [], appointment_notification_minutes: nil
+      )
         @appointments = appointments
         @anniversaries = anniversaries
         @phone_numbers = phone_numbers
         @lists = lists
-        @appointment_notification = appointment_notification
+        @appointment_notification_minutes = appointment_notification_minutes
       end
 
       # Compile packets for EEPROM data.
       #
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
+        validate!
+
         [CPACKET_CLEAR, header] + payloads + [CPACKET_END]
       end
 
@@ -53,7 +67,7 @@ class TimexDatalinkClient
           items_addresses,
           items_lengths,
           earliest_appointment_year,
-          appointment_notification
+          appointment_notification_minutes_value
         ].flatten
       end
 
@@ -89,6 +103,12 @@ class TimexDatalinkClient
         return 0 unless earliest_appointment
 
         earliest_appointment.time.year % 100
+      end
+
+      def appointment_notification_minutes_value
+        return APPOINTMENT_NO_NOTIFICATION unless appointment_notification_minutes
+
+        appointment_notification_minutes / 5
       end
     end
   end

--- a/lib/timex_datalink_client/protocol_3/eeprom.rb
+++ b/lib/timex_datalink_client/protocol_3/eeprom.rb
@@ -51,6 +51,7 @@ class TimexDatalinkClient
 
       # Compile packets for EEPROM data.
       #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
       def packets
         validate!

--- a/spec/lib/timex_datalink_client/protocol_1/eeprom_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/eeprom_spec.rb
@@ -57,7 +57,7 @@ describe TimexDatalinkClient::Protocol1::Eeprom do
     ]
   end
 
-  let(:appointment_notification) { 0xff }
+  let(:appointment_notification_minutes) { nil }
 
   let(:eeprom) do
     described_class.new(
@@ -65,7 +65,7 @@ describe TimexDatalinkClient::Protocol1::Eeprom do
       anniversaries:,
       phone_numbers:,
       lists:,
-      appointment_notification:
+      appointment_notification_minutes:
     )
   end
 
@@ -215,8 +215,8 @@ describe TimexDatalinkClient::Protocol1::Eeprom do
       ]
     end
 
-    context "when appointment_notification is 2" do
-      let(:appointment_notification) { 2 }
+    context "when appointment_notification_minutes is 10" do
+      let(:appointment_notification_minutes) { 10 }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x60, 0x06],
@@ -243,6 +243,18 @@ describe TimexDatalinkClient::Protocol1::Eeprom do
         [0x61, 0x06, 0x0f, 0x0a, 0x15, 0x1d, 0x46, 0x76, 0x91, 0x43, 0x36, 0x4e, 0x85, 0x6d, 0x8e, 0x72, 0xfd],
         [0x62]
       ]
+    end
+
+    context "when appointment_notification_minutes is 1" do
+      let(:appointment_notification_minutes) { 1 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Appointment notification minutes value 1 is invalid!  Valid appointment notification" \
+          " minutes values are [0, 5, 10, 15, 20, 25, 30] or nil."
+        )
+      end
     end
   end
 end

--- a/spec/lib/timex_datalink_client/protocol_3/eeprom_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/eeprom_spec.rb
@@ -57,7 +57,7 @@ describe TimexDatalinkClient::Protocol3::Eeprom do
     ]
   end
 
-  let(:appointment_notification) { 0xff }
+  let(:appointment_notification_minutes) { nil }
 
   let(:eeprom) do
     described_class.new(
@@ -65,7 +65,7 @@ describe TimexDatalinkClient::Protocol3::Eeprom do
       anniversaries:,
       phone_numbers:,
       lists:,
-      appointment_notification:
+      appointment_notification_minutes:
     )
   end
 
@@ -200,8 +200,8 @@ describe TimexDatalinkClient::Protocol3::Eeprom do
       ]
     end
 
-    context "when appointment_notification is 2" do
-      let(:appointment_notification) { 2 }
+    context "when appointment_notification_minutes is 10" do
+      let(:appointment_notification_minutes) { 10 }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x93, 0x01],
@@ -225,6 +225,18 @@ describe TimexDatalinkClient::Protocol3::Eeprom do
         [0x91, 0x01, 0x05, 0x43, 0x36, 0x4e, 0x85, 0x6d, 0x8e, 0x72, 0xfd],
         [0x92, 0x01]
       ]
+    end
+
+    context "when appointment_notification_minutes is 1" do
+      let(:appointment_notification_minutes) { 1 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Appointment notification minutes value 1 is invalid!  Valid appointment notification" \
+          " minutes values are [0, 5, 10, 15, 20, 25, 30] or nil."
+        )
+      end
     end
   end
 end

--- a/spec/lib/timex_datalink_client/protocol_4/eeprom_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/eeprom_spec.rb
@@ -57,7 +57,7 @@ describe TimexDatalinkClient::Protocol4::Eeprom do
     ]
   end
 
-  let(:appointment_notification) { 0xff }
+  let(:appointment_notification_minutes) { nil }
 
   let(:eeprom) do
     described_class.new(
@@ -65,7 +65,7 @@ describe TimexDatalinkClient::Protocol4::Eeprom do
       anniversaries:,
       phone_numbers:,
       lists:,
-      appointment_notification:
+      appointment_notification_minutes:
     )
   end
 
@@ -200,8 +200,8 @@ describe TimexDatalinkClient::Protocol4::Eeprom do
       ]
     end
 
-    context "when appointment_notification is 2" do
-      let(:appointment_notification) { 2 }
+    context "when appointment_notification_minutes is 10" do
+      let(:appointment_notification_minutes) { 10 }
 
       it_behaves_like "CRC-wrapped packets", [
         [0x93, 0x01],
@@ -225,6 +225,18 @@ describe TimexDatalinkClient::Protocol4::Eeprom do
         [0x91, 0x01, 0x05, 0x43, 0x36, 0x4e, 0x85, 0x6d, 0x8e, 0x72, 0xfd],
         [0x92, 0x01]
       ]
+    end
+
+    context "when appointment_notification_minutes is 1" do
+      let(:appointment_notification_minutes) { 1 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Appointment notification minutes value 1 is invalid!  Valid appointment notification" \
+          " minutes values are [0, 5, 10, 15, 20, 25, 30] or nil."
+        )
+      end
     end
   end
 end

--- a/spec/lib/timex_datalink_client_spec.rb
+++ b/spec/lib/timex_datalink_client_spec.rb
@@ -27,7 +27,7 @@ describe TimexDatalinkClient do
             message: "release timexdl.exe"
           )
         ],
-        appointment_notification: 0
+        appointment_notification_minutes: 0
       ),
       TimexDatalinkClient::Protocol3::End.new
     ]


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/248!

This PR renames `Eeprom`'s `appointment_notification` value to `appointment_notification_minutes`, and uses real minute values for this value.  The notifications are in 5 minute intervals from 0 to 30, with a "no notification" of 0xff, or 255.

This is what it looks like in the original Datalink software:

![image](https://user-images.githubusercontent.com/820984/209503080-cdf527d5-19db-45fa-9a9c-9164f780e943.png)

Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent `Appointment` `appointment_notification_minutes` values:

|Timex Datalink Watch pre-notification beep value|`Appointment` `appointment_notification_minutes` value|
|---|---|
|No beep|`nil`|
|At time of appointments|`0`|
|5 minutes before appointments|`5`|
|10 minutes before appointments|`10`|
|15 minutes before appointments|`15`|
|20 minutes before appointments|`20`|
|25 minutes before appointments|`25`|
|30 minutes before appointments|`30`|