### PR TITLE
Set Rubocop's Layout/LineLength to 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,7 @@ inherit_gem:
 
 AllCops:
   NewCops: enable
+
+Layout/LineLength:
+  Enabled: true
+  Max: 120

--- a/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/speech.rb
@@ -155,7 +155,10 @@ class TimexDatalinkClient
           value_4_length = device_nickname.any? ? NICKNAME_LENGTH_WITH_DEVICE : NICKNAME_LENGTH_WITHOUT_DEVICE
 
           value_4_length.times.flat_map do |value_4_index|
-            device_value = HEADER_VALUE_4_DEVICE_INDEXES[value_4_index].sum { |device_index| packet_lengths[device_index] }
+            device_value = HEADER_VALUE_4_DEVICE_INDEXES[value_4_index].sum do |device_index|
+              packet_lengths[device_index]
+            end
+
             device_value *= HEADER_VALUE_4_DEVICE_MULTIPLIERS[value_4_index]
 
             user_value = HEADER_VALUE_4_USER_INDEXES[value_4_index].sum { |device_index| packet_lengths[device_index] }


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/251!

Quick PR to set Rubocop's Layout/LineLength to 120 :+1: 