### PR TITLE
Add lint CI job for markdown documents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: find * -type f -name '*.md' -print0 | xargs -r0 mdl
+      - run: find * -type f -name '*.md' -print0 | xargs -r0 bundle exec mdl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: find * -type f -name '*.md' -print0 | xargs -r0 bundle exec mdl
+      - run: find * -type f -name '*.md' ! -path 'vendor/*' -print0 | xargs -r0 bundle exec mdl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
       - run: gem build timex_datalink_client.gemspec
       - run: gem install timex_datalink_client-*.gem
       - run: ruby -e 'require "timex_datalink_client"'
+
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: find * -type f -name '*.md' -print0 | xargs -r0 mdl

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 all
 
 rule "MD013", line_length: 120

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,0 +1,7 @@
+all
+
+rule "MD013", line_length: 120
+rule "MD026", punctuation: ".,;:"
+
+exclude_rule "MD033"
+exclude_rule "MD034"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "#{File.dirname(__FILE__)}/.mdl_style.rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,8 @@ GEM
       tzinfo (~> 2.0)
     ast (2.4.2)
     backports (3.23.0)
+    chef-utils (18.0.185)
+      concurrent-ruby
     concurrent-ruby (1.1.10)
     crc (0.4.2)
     diff-lcs (1.5.0)
@@ -26,8 +28,23 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     mdb (0.5.0)
+    mdl (0.12.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
     minitest (5.16.3)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-shellout (3.2.7)
+      chef-utils
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -74,6 +91,7 @@ GEM
     ruby-progressbar (1.11.0)
     rubyserial (0.6.0)
       ffi (~> 1.9, >= 1.9.3)
+    tomlrb (2.0.3)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
@@ -89,6 +107,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  mdl (~> 0.12.0)
   rspec (~> 3.11.0)
   rubocop (~> 1.41.1)
   rubocop-github (~> 0.20.0)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you need to install Ruby, follow the
 
 Then, with Ruby installed, run this command to install the timex\_datalink\_client gem:
 
-```
+```shell
 gem install timex_datalink_client
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,21 +92,21 @@ below to identify the protocol.
     <td>
       <image src="https://user-images.githubusercontent.com/820984/189609399-25eea5c5-958e-489d-936e-139342c9fddf.png">
     </td>
-    <td>Use protocol 1 models in <code>TimexDatalinkClient::Protocol3</code></td>
+    <td>Use protocol 3 models in <code>TimexDatalinkClient::Protocol3</code></td>
   </tr>
 
   <tr>
     <td>
       <image src="https://user-images.githubusercontent.com/820984/189609671-33a6dc6b-1eb1-4942-8bac-238e6056d1c2.png">
     </td>
-    <td>Use protocol 1 models in <code>TimexDatalinkClient::Protocol4</code></td>
+    <td>Use protocol 4 models in <code>TimexDatalinkClient::Protocol4</code></td>
   </tr>
 
   <tr>
     <td>
       <image src="https://user-images.githubusercontent.com/820984/190122029-6df17bd0-171a-425c-ac63-d415eeb9fffd.png">
     </td>
-    <td>Use protocol 1 models in <code>TimexDatalinkClient::Protocol9</code></td>
+    <td>Use protocol 9 models in <code>TimexDatalinkClient::Protocol9</code></td>
   </tr>
 
   <tr>

--- a/README.md
+++ b/README.md
@@ -75,13 +75,47 @@ On Timex Datalink watches, pressing the center button on the right will change i
 MODE" is displayed, then "COMM READY" will appear.  This is sometimes accompanied by a version number.  Use the table
 below to identify the protocol.
 
-|Watch display|Protocol compatibility|
-|---|---|
-|![image](https://user-images.githubusercontent.com/820984/189607899-5bb67438-1c82-41e0-95d1-d1134cfb1f8b.png)|Use protocol 1 models in `TimexDatalinkClient::Protocol1`|
-|![image](https://user-images.githubusercontent.com/820984/189609399-25eea5c5-958e-489d-936e-139342c9fddf.png)|Use protocol 3 models in `TimexDatalinkClient::Protocol3`|
-|![image](https://user-images.githubusercontent.com/820984/189609671-33a6dc6b-1eb1-4942-8bac-238e6056d1c2.png)|Use protocol 4 models in `TimexDatalinkClient::Protocol4`|
-|![image](https://user-images.githubusercontent.com/820984/190122029-6df17bd0-171a-425c-ac63-d415eeb9fffd.png)|Use protocol 9 models in `TimexDatalinkClient::Protocol9`|
-|![image](https://user-images.githubusercontent.com/820984/190326340-3ffba239-ea9e-4595-83ae-c261be284a30.png)|Protocol 6 (currently not supported)|
+<table>
+  <tr>
+    <th>Watch display</th>
+    <th>Protocol compatibility</th>
+  </tr>
+
+  <tr>
+    <td>
+      <image src="https://user-images.githubusercontent.com/820984/189607899-5bb67438-1c82-41e0-95d1-d1134cfb1f8b.png">
+    </td>
+    <td>Use protocol 1 models in <code>TimexDatalinkClient::Protocol1</code></td>
+  </tr>
+
+  <tr>
+    <td>
+      <image src="https://user-images.githubusercontent.com/820984/189609399-25eea5c5-958e-489d-936e-139342c9fddf.png">
+    </td>
+    <td>Use protocol 1 models in <code>TimexDatalinkClient::Protocol3</code></td>
+  </tr>
+
+  <tr>
+    <td>
+      <image src="https://user-images.githubusercontent.com/820984/189609671-33a6dc6b-1eb1-4942-8bac-238e6056d1c2.png">
+    </td>
+    <td>Use protocol 1 models in <code>TimexDatalinkClient::Protocol4</code></td>
+  </tr>
+
+  <tr>
+    <td>
+      <image src="https://user-images.githubusercontent.com/820984/190122029-6df17bd0-171a-425c-ac63-d415eeb9fffd.png">
+    </td>
+    <td>Use protocol 1 models in <code>TimexDatalinkClient::Protocol9</code></td>
+  </tr>
+
+  <tr>
+    <td>
+      <image src="https://user-images.githubusercontent.com/820984/190326340-3ffba239-ea9e-4595-83ae-c261be284a30.png">
+    </td>
+    <td>Protocol 6 (currently not supported)</td>
+  </tr>
+</table>
 
 During data transmission, the "start" packet of each protocol will announce the protocol number to the device.  If the
 protocol doesn't match the device, the screen will display "PC-WATCH MISMATCH" and safely abort the data transmission.

--- a/docs/acquiring_pcvocab.mdb.md
+++ b/docs/acquiring_pcvocab.mdb.md
@@ -23,7 +23,7 @@ possible.
 `pcvocab.mdb` is called `pcvocab.mdb1` in the `Cabs.w4.cab` archive, which is inside of `eBrain.MSI` on the ISO.  We
 need to perform a few extractions, then rename the database file, like so:
 
-```
+```shell
 7z e ebrain-1.1.6.iso eBrain.MSI
 7z e eBrain.MSI Cabs.w4.cab
 7z e Cabs.w4.cab pcvocab.mdb1

--- a/docs/acquiring_spc_and_zap_files.md
+++ b/docs/acquiring_spc_and_zap_files.md
@@ -23,7 +23,7 @@ The SPC and ZAP files are in the `SETUP.EXE` file, which is inside of `TDL21D.EX
 `SETUP.EXE` from `TDL21D.EXE`, create `sound-themes` and `wrist-apps` directories, and extract the SPC and ZAP files to
 the appropriate directories.
 
-```
+```shell
 7z e TDL21D.EXE SETUP.EXE
 7z e SETUP.EXE -osound-themes *.SPC
 7z e SETUP.EXE -owrist-apps *.ZAP

--- a/docs/timex_datalink_protocol_1.md
+++ b/docs/timex_datalink_protocol_1.md
@@ -34,7 +34,8 @@ TimexDatalinkClient::Protocol1::Eeprom.new(
 )
 ```
 
-Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent `Appointment` `appointment_notification_minutes` values:
+Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent
+`Appointment` `appointment_notification_minutes` values:
 
 |Timex Datalink Watch pre-notification beep value|`Appointment` `appointment_notification_minutes` value|
 |---|---|

--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -31,7 +31,8 @@ TimexDatalinkClient::Protocol3::Eeprom.new(
 )
 ```
 
-Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent `Appointment` `appointment_notification_minutes` values:
+Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent
+`Appointment` `appointment_notification_minutes` values:
 
 |Timex Datalink Watch pre-notification beep value|`Appointment` `appointment_notification_minutes` value|
 |---|---|

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -31,7 +31,8 @@ TimexDatalinkClient::Protocol4::Eeprom.new(
 )
 ```
 
-Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent `Appointment` `appointment_notification_minutes` values:
+Here are the available Watch pre-notification beep values from the Timex Datalink software with their equivalent
+`Appointment` `appointment_notification_minutes` values:
 
 |Timex Datalink Watch pre-notification beep value|`Appointment` `appointment_notification_minutes` value|
 |---|---|

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -93,6 +93,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mdb", "~> 0.5.0"
   s.add_dependency "rubyserial", "~> 0.6.0"
 
+  s.add_development_dependency "mdl", "~> 0.12.0"
   s.add_development_dependency "rspec", "~> 3.11.0"
   s.add_development_dependency "rubocop", "~> 1.41.1"
   s.add_development_dependency "rubocop-github", "~> 0.20.0"


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/253!

This PR adds a lint CI job for markdown documents, and fixes some lint issues :+1: 