### PR TITLE
Add protocol 6 Time class

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -46,6 +46,7 @@ require "timex_datalink_client/protocol_4/wrist_app"
 require "timex_datalink_client/protocol_6/end"
 require "timex_datalink_client/protocol_6/start"
 require "timex_datalink_client/protocol_6/sync"
+require "timex_datalink_client/protocol_6/time"
 
 require "timex_datalink_client/protocol_7/eeprom"
 require "timex_datalink_client/protocol_7/eeprom/activity"

--- a/lib/timex_datalink_client/helpers/char_encoders.rb
+++ b/lib/timex_datalink_client/helpers/char_encoders.rb
@@ -4,6 +4,7 @@ class TimexDatalinkClient
   class Helpers
     module CharEncoders
       CHARS = "0123456789abcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:\\;=@?_|<>[]"
+      CHARS_PROTOCOL_6 = "0123456789 abcdefghijklmnopqrstuvwxyz!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
       EEPROM_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz !\"#$%&'()*+,-./:\\;=@?_|<>["
       PHONE_CHARS = "0123456789cfhpw "
       INVALID_CHAR = " "
@@ -17,6 +18,10 @@ class TimexDatalinkClient
         formatted_chars.each_char.map do |char|
           char_map.index(char) || char_map.index(INVALID_CHAR)
         end
+      end
+
+      def protocol_6_chars_for(string_chars, length: nil, pad: false)
+        chars_for(string_chars, char_map: CHARS_PROTOCOL_6, length: length, pad: pad)
       end
 
       def eeprom_chars_for(string_chars, length: 31)

--- a/lib/timex_datalink_client/helpers/char_encoders.rb
+++ b/lib/timex_datalink_client/helpers/char_encoders.rb
@@ -21,7 +21,7 @@ class TimexDatalinkClient
       end
 
       def protocol_6_chars_for(string_chars, length: nil, pad: false)
-        chars_for(string_chars, char_map: CHARS_PROTOCOL_6, length: length, pad: pad)
+        chars_for(string_chars, char_map: CHARS_PROTOCOL_6, length:, pad:)
       end
 
       def eeprom_chars_for(string_chars, length: 31)

--- a/lib/timex_datalink_client/protocol_6/time.rb
+++ b/lib/timex_datalink_client/protocol_6/time.rb
@@ -95,7 +95,9 @@ class TimexDatalinkClient
       # @param flex_time_zone [Boolean] Toggle using FLEXtime to set time zone.
       # @param flex_dst [Boolean] Toggle using FLEXtime to apply daylight savings time offset.
       # @return [Time] Time instance.
-      def initialize(zone:, is_24h:, date_format:, time:, name: nil, flex_time: false, flex_time_zone: false, flex_dst: false)
+      def initialize(
+        zone:, is_24h:, date_format:, time:, name: nil, flex_time: false, flex_time_zone: false, flex_dst: false
+      )
         @zone = zone
         @is_24h = is_24h
         @date_format = date_format

--- a/lib/timex_datalink_client/protocol_6/time.rb
+++ b/lib/timex_datalink_client/protocol_6/time.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "active_model"
+
+require "timex_datalink_client/helpers/char_encoders"
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol6
+    class Time
+      include ActiveModel::Validations
+      include Helpers::CharEncoders
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_TIME = [0x32].freeze
+      CPACKET_FLEX_TIME = [0x33].freeze
+
+      ZONE_OFFSET_MAP = {
+        -39600 => 0x15,
+        -36000 => 0x16,
+        -32400 => 0x17,
+        -28800 => 0x18,
+        -25200 => 0x19,
+        -21600 => 0x1a,
+        -18000 => 0x1b,
+        -14400 => 0x1c,
+        -12600 => 0x14,
+        -10800 => 0x1d,
+        -7200 => 0x1e,
+        -3600 => 0x1f,
+        0 => 0x00,
+        3600 => 0x01,
+        7200 => 0x02,
+        10800 => 0x03,
+        12600 => 0x0d,
+        14400 => 0x04,
+        16200 => 0x0e,
+        18000 => 0x05,
+        19800 => 0x0f,
+        20700 => 0x11,
+        21600 => 0x06,
+        23400 => 0x12,
+        25200 => 0x07,
+        28800 => 0x08,
+        32400 => 0x09,
+        34200 => 0x13,
+        36000 => 0x0a,
+        39600 => 0x0b,
+        43200 => 0x0c
+      }.freeze
+
+      FLEX_TIME_ZONE = 0x10
+      FLEX_DST_VALUE = 0x08
+
+      DATE_FORMAT_MAP = {
+        "%_m-%d-%y" => 0x00,
+        "%_d-%m-%y" => 0x01,
+        "%y-%m-%d" => 0x02,
+        "%_m.%d.%y" => 0x04,
+        "%_d.%m.%y" => 0x05,
+        "%y.%m.%d" => 0x06
+      }.freeze
+
+      validates :zone, inclusion: {
+        in: 1..2,
+        message: "%{value} is invalid!  Valid zones are 1..2."
+      }
+
+      validates :date_format, inclusion: {
+        in: DATE_FORMAT_MAP.keys,
+        message: "%{value} is invalid!  Valid date formats are #{DATE_FORMAT_MAP.keys}."
+      }
+
+      validates :flex_time_zone, unless: :flex_time, inclusion: {
+        in: [false],
+        message: "cannot be enabled unless FLEXtime is also enabled."
+      }
+
+      validates :flex_dst, unless: :flex_time, inclusion: {
+        in: [false],
+        message: "cannot be enabled unless FLEXtime is also enabled."
+      }
+
+      attr_accessor :zone, :is_24h, :date_format, :time, :name, :flex_time, :flex_time_zone, :flex_dst
+
+      # Create a Time instance.
+      #
+      # @param zone [Integer] Time zone number (1 or 2).
+      # @param is_24h [Boolean] Toggle 24 hour time.
+      # @param date_format ["%_m-%d-%y", "%_d-%m-%y", "%y-%m-%d", "%_m.%d.%y", "%_d.%m.%y", "%y.%m.%d"] Date format
+      #   (represented by Time#strftime format).
+      # @param time [::Time] Time to set (including time zone).
+      # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max).
+      # @param flex_time [Boolean] Toggle using FLEXtime to set time and date.
+      # @param flex_time_zone [Boolean] Toggle using FLEXtime to set time zone.
+      # @param flex_dst [Boolean] Toggle using FLEXtime to apply daylight savings time offset.
+      # @return [Time] Time instance.
+      def initialize(zone:, is_24h:, date_format:, time:, name: nil, flex_time: false, flex_time_zone: false, flex_dst: false)
+        @zone = zone
+        @is_24h = is_24h
+        @date_format = date_format
+        @time = time
+        @name = name
+        @flex_time = flex_time
+        @flex_time_zone = flex_time_zone
+        @flex_dst = flex_dst
+      end
+
+      # Compile packets for a time.
+      #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        validate!
+
+        [
+          [
+            cpacket,
+            zone,
+            second,
+            hour,
+            minute,
+            month,
+            day,
+            year_mod_1900,
+            name_characters,
+            wday_from_monday,
+            formatted_time_zone,
+            is_24h_value,
+            date_format_value
+          ].flatten
+        ]
+      end
+
+      private
+
+      def cpacket
+        flex_time ? CPACKET_FLEX_TIME : CPACKET_TIME
+      end
+
+      def second
+        flex_time ? 0 : formatted_time.sec
+      end
+
+      def hour
+        flex_time ? 0 : formatted_time.hour
+      end
+
+      def minute
+        flex_time ? 0 : formatted_time.min
+      end
+
+      def month
+        flex_time ? 0 : formatted_time.month
+      end
+
+      def day
+        flex_time ? 0 : formatted_time.day
+      end
+
+      def formatted_name
+        return name if name
+        return time.zone if time.zone
+
+        "TZ#{zone}"
+      end
+
+      def name_characters
+        protocol_6_chars_for(formatted_name, length: 3, pad: true)
+      end
+
+      def year_mod_1900
+        flex_time ? 0 : formatted_time.year % 100
+      end
+
+      def wday_from_monday
+        flex_time ? 0 : (formatted_time.wday + 6) % 7
+      end
+
+      def formatted_time
+        time.dst? ? time + 3600 : time
+      end
+
+      def formatted_utc_offset
+        time.dst? ? time.utc_offset - 3600 : time.utc_offset
+      end
+
+      def formatted_time_zone
+        flex_time_zone ? FLEX_TIME_ZONE : ZONE_OFFSET_MAP[formatted_utc_offset]
+      end
+
+      def is_24h_value
+        is_24h ? 2 : 1
+      end
+
+      def date_format_value
+        format = DATE_FORMAT_MAP.fetch(date_format)
+        format += FLEX_DST_VALUE if flex_dst
+
+        format
+      end
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -66,6 +66,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_6/end.rb",
     "lib/timex_datalink_client/protocol_6/start.rb",
     "lib/timex_datalink_client/protocol_6/sync.rb",
+    "lib/timex_datalink_client/protocol_6/time.rb",
 
     "lib/timex_datalink_client/protocol_7/eeprom.rb",
     "lib/timex_datalink_client/protocol_7/eeprom/activity.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/257!

This PR adds Protocol6::Time, the Time class used for the Motorola Beepwear Pro!

This one was a bit tricky: this watch's protocol cares a lot about time zones.  In the other protocols, there are "time zone names," which typically presents itself as PDT, UTC, etc., but it can be any three-character label you'd like.  Other than that, the time zone is not considered when actually setting the time on the watch.

In protocol 6 for the Beepwear Pro, when you set the time, you also set the time zone.  When the time zone is in daylight savings, the non-DST zone is still used, and the hour is literally advanced by one in time data.  There is also the ability to enable FLEXtime, which will set your time for you from the FLEX network, and it can also set the time zone and adjust for daylight savings automatically, if you wish.

When FLEXtime is enabled, the year, month, day, day of week, hour, minute, and second values are all set to zero.  With the automatic DST adjustment on, the date format value increases by 8.  My guess is that Timex and Motorola repurposed the unused bit in this value for this feature.

Protocol 6 also uses a unique character set, so this was added in this PR to make Time behave correctly.  I added all the characters that were able to be selected when setting the time zone name manually.