### PR TITLE
Add protocol 6 PagerOptions model

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -44,6 +44,7 @@ require "timex_datalink_client/protocol_4/time"
 require "timex_datalink_client/protocol_4/wrist_app"
 
 require "timex_datalink_client/protocol_6/end"
+require "timex_datalink_client/protocol_6/pager_options"
 require "timex_datalink_client/protocol_6/start"
 require "timex_datalink_client/protocol_6/sync"
 require "timex_datalink_client/protocol_6/time"

--- a/lib/timex_datalink_client/protocol_6/pager_options.rb
+++ b/lib/timex_datalink_client/protocol_6/pager_options.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol6
+    class PagerOptions
+      include ActiveModel::Validations
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_PAGER = 0x73
+      ALERT_SOUND_SILENT = 6
+
+      validates :on_hour, inclusion: {
+        in: 0..23,
+        message: "%{value} is invalid!  Valid on hour values are 0..23."
+      }
+
+      validates :on_minute, inclusion: {
+        in: 0..59,
+        message: "%{value} is invalid!  Valid on minute values are 0..59."
+      }
+
+      validates :off_hour, inclusion: {
+        in: 0..23,
+        message: "%{value} is invalid!  Valid off hour values are 0..23."
+      }
+
+      validates :off_minute, inclusion: {
+        in: 0..59,
+        message: "%{value} is invalid!  Valid off minute values are 0..59."
+      }
+
+      validates :alert_sound, inclusion: {
+        in: 0..5,
+        allow_nil: true,
+        message: "%{value} is invalid!  Valid alert sound values are 0..5 and nil."
+      }
+
+      attr_accessor :auto_on_off, :on_hour, :on_minute, :off_hour, :off_minute, :alert_sound
+
+      # Create a PagerOptions instance.
+      #
+      # @param auto_on_off [Boolean] Toggle turning pager on and off every day.
+      # @param on_hour [Integer] Hour to turn pager on at.
+      # @param on_minute [Integer] Minute to turn pager on at.
+      # @param off_hour [Integer] Hour to turn pager off at.
+      # @param off_minute [Integer] Minute to turn pager off at.
+      # @param alert_sound [Integer, nil] Pager alert sound (0 to 5 or nil for silent).
+      # @return [PagerOptions] PagerOptions instance.
+      def initialize(auto_on_off:, on_hour:, on_minute:, off_hour:, off_minute:, alert_sound:)
+        @auto_on_off = auto_on_off
+        @on_hour = on_hour
+        @on_minute = on_minute
+        @off_hour = off_hour
+        @off_minute = off_minute
+        @alert_sound = alert_sound
+      end
+
+      # Compile packets for sound options.
+      #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        validate!
+
+        [
+          [
+            CPACKET_PAGER,
+            auto_on_off_formatted,
+            on_hour,
+            on_minute,
+            off_hour,
+            off_minute,
+            alert_sound_formatted
+          ]
+        ]
+      end
+
+      def auto_on_off_formatted
+        auto_on_off ? 1 : 0
+      end
+
+      def alert_sound_formatted
+        alert_sound || ALERT_SOUND_SILENT
+      end
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_6/pager_options.rb
+++ b/lib/timex_datalink_client/protocol_6/pager_options.rb
@@ -48,7 +48,7 @@ class TimexDatalinkClient
       # @param off_minute [Integer] Minute to turn pager off at.
       # @param alert_sound [Integer, nil] Pager alert sound (0 to 5 or nil for silent).
       # @return [PagerOptions] PagerOptions instance.
-      def initialize(auto_on_off:, on_hour:, on_minute:, off_hour:, off_minute:, alert_sound:)
+      def initialize(auto_on_off: false, on_hour: 0, on_minute: 0, off_hour: 0, off_minute: 0, alert_sound: 0)
         @auto_on_off = auto_on_off
         @on_hour = on_hour
         @on_minute = on_minute

--- a/lib/timex_datalink_client/protocol_6/pager_options.rb
+++ b/lib/timex_datalink_client/protocol_6/pager_options.rb
@@ -57,7 +57,7 @@ class TimexDatalinkClient
         @alert_sound = alert_sound
       end
 
-      # Compile packets for sound options.
+      # Compile packets for pager options.
       #
       # @raise [ActiveModel::ValidationError] One or more model values are invalid.
       # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.

--- a/spec/lib/timex_datalink_client/protocol_6/pager_options_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/pager_options_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol6::PagerOptions do
+  let(:auto_on_off) { false }
+  let(:on_hour) { 12 }
+  let(:on_minute) { 34 }
+  let(:off_hour) { 18 }
+  let(:off_minute) { 56 }
+  let(:alert_sound) { 0 }
+
+  let(:pager_options) do
+    described_class.new(
+      auto_on_off:,
+      on_hour:,
+      on_minute:,
+      off_hour:,
+      off_minute:,
+      alert_sound:
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { pager_options.packets }
+
+    it_behaves_like "CRC-wrapped packets", [[0x73, 0x00, 0x0c, 0x22, 0x12, 0x38, 0x00]]
+
+    context "when auto_on_off is true" do
+      let(:auto_on_off) { true }
+
+      it_behaves_like "CRC-wrapped packets", [[0x73, 0x01, 0x0c, 0x22, 0x12, 0x38, 0x00]]
+    end
+
+    context "when on_hour is 6" do
+      let(:on_hour) { 6 }
+
+      it_behaves_like "CRC-wrapped packets", [[0x73, 0x00, 0x06, 0x22, 0x12, 0x38, 0x00]]
+    end
+
+    context "when on_hour is 25" do
+      let(:on_hour) { 25 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: On hour 25 is invalid!  Valid on hour values are 0..23."
+        )
+      end
+    end
+
+    context "when on_minute is 3" do
+      let(:on_minute) { 3 }
+
+      it_behaves_like "CRC-wrapped packets", [[0x73, 0x00, 0x0c, 0x03, 0x12, 0x38, 0x00]]
+    end
+
+    context "when on_minute is 60" do
+      let(:on_minute) { 60 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: On minute 60 is invalid!  Valid on minute values are 0..59."
+        )
+      end
+    end
+
+    context "when off_hour is 4" do
+      let(:off_hour) { 4 }
+
+      it_behaves_like "CRC-wrapped packets", [[0x73, 0x00, 0x0c, 0x22, 0x04, 0x38, 0x00]]
+    end
+
+    context "when off_hour is 25" do
+      let(:off_hour) { 25 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Off hour 25 is invalid!  Valid off hour values are 0..23."
+        )
+      end
+    end
+
+    context "when off_minute is 9" do
+      let(:off_minute) { 9 }
+
+      it_behaves_like "CRC-wrapped packets", [[0x73, 0x00, 0x0c, 0x22, 0x12, 0x09, 0x00]]
+    end
+
+    context "when off_minute is 60" do
+      let(:off_minute) { 60 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Off minute 60 is invalid!  Valid off minute values are 0..59."
+        )
+      end
+    end
+
+    context "when alert_sound is 3" do
+      let(:alert_sound) { 3 }
+
+      it_behaves_like "CRC-wrapped packets", [[0x73, 0x00, 0x0c, 0x22, 0x12, 0x38, 0x03]]
+    end
+
+    context "when alert_sound is nil" do
+      let(:alert_sound) { nil }
+
+      it_behaves_like "CRC-wrapped packets", [[0x73, 0x00, 0x0c, 0x22, 0x12, 0x38, 0x06]]
+    end
+
+    context "when alert_sound is 6" do
+      let(:alert_sound) { 6 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Alert sound 6 is invalid!  Valid alert sound values are 0..5 and nil."
+        )
+      end
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_4/wrist_app.rb",
 
     "lib/timex_datalink_client/protocol_6/end.rb",
+    "lib/timex_datalink_client/protocol_6/pager_options.rb",
     "lib/timex_datalink_client/protocol_6/start.rb",
     "lib/timex_datalink_client/protocol_6/sync.rb",
     "lib/timex_datalink_client/protocol_6/time.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/258!

This PR adds Protocol6::PagerOptions!

Use it like this:

```ruby
models = [
  TimexDatalinkClient::Protocol6::Sync.new,
  TimexDatalinkClient::Protocol6::Start.new,
  TimexDatalinkClient::Protocol6::PagerOptions.new(
    auto_on_off: true,
    on_hour: 12,
    on_minute: 34,
    off_hour: 15,
    off_minute: 45,
    alert_sound: 1
  ),
  TimexDatalinkClient::Protocol6::End.new
]

client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models
)

client.write
```

This data covers every field in the Pager options in the original software:

![image](https://user-images.githubusercontent.com/820984/221487416-4130b18a-92c8-46d7-aee8-a29af63dc87e.png)