### PR TITLE
Add protocol 6 NightModeOptions class

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -44,6 +44,7 @@ require "timex_datalink_client/protocol_4/time"
 require "timex_datalink_client/protocol_4/wrist_app"
 
 require "timex_datalink_client/protocol_6/end"
+require "timex_datalink_client/protocol_6/night_mode_options"
 require "timex_datalink_client/protocol_6/pager_options"
 require "timex_datalink_client/protocol_6/start"
 require "timex_datalink_client/protocol_6/sync"

--- a/lib/timex_datalink_client/protocol_6/night_mode_options.rb
+++ b/lib/timex_datalink_client/protocol_6/night_mode_options.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol6
+    class NightModeOptions
+      include ActiveModel::Validations
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_NIGHT_MODE = 0x72
+
+      validates :night_mode_deactivate_hours, inclusion: {
+        in: 3..12,
+        message: "%{value} is invalid!  Valid night mode deactivate hour values are 3..12."
+      }
+
+      validates :indiglo_timeout_seconds, inclusion: {
+        in: 3..10,
+        message: "%{value} is invalid!  Valid Indiglo timeout second values are 3..10."
+      }
+
+      attr_accessor :night_mode_deactivate_hours, :indiglo_timeout_seconds, :night_mode_on_notification
+
+      # Create a NightModeOptions instance.
+      #
+      # @param night_mode_deactivate_hours [Integer] Automatically deactivate night mode after specified hours.
+      # @param indiglo_timeout_seconds [Integer] Turn Indiglo light off after specified seconds after each button push.
+      # @param night_mode_on_notification [Boolean] Toggle activating night mode on any pager or alarm event.
+      # @return [NightModeOptions] NightModeOptions instance.
+      def initialize(night_mode_deactivate_hours: 8, indiglo_timeout_seconds: 4, night_mode_on_notification: false)
+        @night_mode_deactivate_hours = night_mode_deactivate_hours
+        @indiglo_timeout_seconds = indiglo_timeout_seconds
+        @night_mode_on_notification = night_mode_on_notification
+      end
+
+      # Compile packets for night mode options.
+      #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        validate!
+
+        [
+          [
+            CPACKET_NIGHT_MODE,
+            night_mode_on_notification_formatted,
+            night_mode_deactivate_hours,
+            indiglo_timeout_seconds
+          ]
+        ]
+      end
+
+      def night_mode_on_notification_formatted
+        night_mode_on_notification ? 1 : 0
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_6/night_mode_options_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/night_mode_options_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol6::NightModeOptions do
+  let(:night_mode_deactivate_hours) { 8 }
+  let(:indiglo_timeout_seconds) { 4 }
+  let(:night_mode_on_notification) { false }
+
+  let(:night_mode_options) do
+    described_class.new(
+      night_mode_deactivate_hours:,
+      indiglo_timeout_seconds:,
+      night_mode_on_notification:
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { night_mode_options.packets }
+
+    it_behaves_like "CRC-wrapped packets", [[0x72, 0x00, 0x08, 0x04]]
+
+    context "when night_mode_deactivate_hours is 12" do
+      let(:night_mode_deactivate_hours) { 12 }
+
+      it_behaves_like "CRC-wrapped packets", [[0x72, 0x00, 0x0c, 0x04]]
+    end
+
+    context "when night_mode_deactivate_hours is 13" do
+      let(:night_mode_deactivate_hours) { 13 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Night mode deactivate hours 13 is invalid!  Valid night mode deactivate hour values " \
+          "are 3..12."
+        )
+      end
+    end
+
+    context "when indiglo_timeout_seconds is 19" do
+      let(:indiglo_timeout_seconds) { 10 }
+
+      it_behaves_like "CRC-wrapped packets", [[0x72, 0x00, 0x08, 0x0a]]
+    end
+
+    context "when indiglo_timeout_seconds is 11" do
+      let(:indiglo_timeout_seconds) { 11 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Indiglo timeout seconds 11 is invalid!  Valid Indiglo timeout second values are 3..10."
+        )
+      end
+    end
+
+    context "when night_mode_on_notification is 12" do
+      let(:night_mode_on_notification) { true }
+
+      it_behaves_like "CRC-wrapped packets", [[0x72, 0x01, 0x08, 0x04]]
+    end
+  end
+end

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_4/wrist_app.rb",
 
     "lib/timex_datalink_client/protocol_6/end.rb",
+    "lib/timex_datalink_client/protocol_6/night_mode_options.rb",
     "lib/timex_datalink_client/protocol_6/pager_options.rb",
     "lib/timex_datalink_client/protocol_6/start.rb",
     "lib/timex_datalink_client/protocol_6/sync.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/268! :tada: 

This PR adds Protocol6::NightModeOptions!

Use it like this:

```ruby
models = [
  TimexDatalinkClient::Protocol6::Sync.new,
  TimexDatalinkClient::Protocol6::Start.new,
  TimexDatalinkClient::Protocol6::NightModeOptions.new(
    night_mode_deactivate_hours: 12,
    indiglo_timeout_seconds: 10,
    night_mode_on_notification: true
  ),
  TimexDatalinkClient::Protocol6::End.new
]

client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models
)

client.write
```

This data covers every field in the Night-Mode options in the original software:

![image](https://user-images.githubusercontent.com/820984/221494830-2a763a0d-7285-40b7-993a-79edd6709bc5.png)
