### PR TITLE
Add protocol 6 Alarm class

### DIFF
--- a/lib/timex_datalink_client.rb
+++ b/lib/timex_datalink_client.rb
@@ -43,6 +43,7 @@ require "timex_datalink_client/protocol_4/sync"
 require "timex_datalink_client/protocol_4/time"
 require "timex_datalink_client/protocol_4/wrist_app"
 
+require "timex_datalink_client/protocol_6/alarm"
 require "timex_datalink_client/protocol_6/end"
 require "timex_datalink_client/protocol_6/night_mode_options"
 require "timex_datalink_client/protocol_6/pager_options"

--- a/lib/timex_datalink_client/protocol_6/alarm.rb
+++ b/lib/timex_datalink_client/protocol_6/alarm.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "active_model"
+
+require "timex_datalink_client/helpers/char_encoders"
+require "timex_datalink_client/helpers/crc_packets_wrapper"
+
+class TimexDatalinkClient
+  class Protocol6
+    class Alarm
+      include ActiveModel::Validations
+      include Helpers::CharEncoders
+      prepend Helpers::CrcPacketsWrapper
+
+      CPACKET_ALARM = 0x51
+
+      VALID_DAYS_IN_MONTH = {
+        1 => 1..31,
+        2 => 1..29,
+        3 => 1..31,
+        4 => 1..30,
+        5 => 1..31,
+        6 => 1..30,
+        7 => 1..31,
+        8 => 1..31,
+        9 => 1..30,
+        10 => 1..31,
+        11 => 1..30,
+        12 => 1..31
+      }.freeze
+
+      ALARM_STATUS_MAP = {
+        disarmed: 0,
+        armed: 1,
+        unused: 2
+      }.freeze
+
+      DEFAULT_TIME = Time.new(0, 1, 1, 6, 0)
+
+      attr_accessor :number, :status, :time, :message, :month, :day
+
+      validates :number, inclusion: {
+        in: 1..8,
+        message: "value %{value} is invalid!  Valid number values are 1..8."
+      }
+
+      validates :status, inclusion: {
+        in: ALARM_STATUS_MAP.keys,
+        message: "%{value} is invalid!  Valid date formats are #{ALARM_STATUS_MAP.keys}."
+      }
+
+      validates :month, inclusion: {
+        in: 1..12,
+        allow_nil: true,
+        message: "%{value} is invalid!  Valid months are 1..12 and nil."
+      }
+
+      validates :day, inclusion: {
+        if: ->(alarm) { alarm.month.nil? },
+        in: 1..31,
+        allow_nil: true,
+        message: "%{value} is invalid!  Valid days are 1..31 and nil."
+      }
+
+      validates :day, inclusion: {
+        if: ->(alarm) { alarm.day && alarm.month },
+        in: ->(alarm) { VALID_DAYS_IN_MONTH[alarm.month] },
+        message: ->(alarm, _attributes) do
+          "#{alarm.day} is invalid for month #{alarm.month}!  " \
+          "Valid days are #{VALID_DAYS_IN_MONTH[alarm.month]} and nil when month is #{alarm.month}."
+        end
+      }
+
+      # Create an Alarm instance.
+      #
+      # @param number [Integer] Alarm number (from 1 to 5).
+      # @param status [Symbol] Alarm status (:armed, :disarmed, or :unused).
+      # @param time [::Time] Time of alarm.
+      # @param message [String] Alarm message text.
+      # @param month [Integer, nil] Month of alarm.
+      # @param day [Integer, nil] Day of alarm.
+      # @return [Alarm] Alarm instance.
+      def initialize(number:, status:, time: DEFAULT_TIME, message: "", month: nil, day: nil)
+        @number = number
+        @status = status
+        @time = time
+        @message = message
+        @month = month
+        @day = day
+      end
+
+      # Compile packets for an alarm.
+      #
+      # @raise [ActiveModel::ValidationError] One or more model values are invalid.
+      # @return [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
+      def packets
+        validate!
+
+        [
+          [
+            CPACKET_ALARM,
+            number,
+            time.hour,
+            time.min,
+            month.to_i,
+            day.to_i,
+            status_formatted,
+            message_characters,
+          ].flatten
+        ]
+      end
+
+      private
+
+      def message_characters
+        protocol_6_chars_for(message, length: 16, pad: true)
+      end
+
+      def status_formatted
+        ALARM_STATUS_MAP[status]
+      end
+    end
+  end
+end

--- a/lib/timex_datalink_client/protocol_6/alarm.rb
+++ b/lib/timex_datalink_client/protocol_6/alarm.rb
@@ -73,7 +73,7 @@ class TimexDatalinkClient
 
       # Create an Alarm instance.
       #
-      # @param number [Integer] Alarm number (from 1 to 5).
+      # @param number [Integer] Alarm number (from 1 to 8).
       # @param status [Symbol] Alarm status (:armed, :disarmed, or :unused).
       # @param time [::Time] Time of alarm.
       # @param message [String] Alarm message text.

--- a/spec/lib/timex_datalink_client/protocol_6/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/alarm_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TimexDatalinkClient::Protocol6::Alarm do
+  let(:number) { 1 }
+  let(:status) { :disarmed }
+  let(:time) { Time.new(0, 1, 1, 0, 0) }
+  let(:message) { "Alarm 1" }
+  let(:month) { nil }
+  let(:day) { nil }
+
+  let(:alarm) do
+    described_class.new(
+      number:,
+      status:,
+      time:,
+      message:,
+      month:,
+      day:
+    )
+  end
+
+  describe "#packets", :crc do
+    subject(:packets) { alarm.packets }
+
+    it_behaves_like "CRC-wrapped packets", [
+      [
+        0x51, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x16, 0x0b, 0x1c, 0x17, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x0a,
+        0x0a, 0x0a, 0x0a, 0x0a, 0x0a
+      ]
+    ]
+
+    context "when number is 2" do
+      let(:number) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x16, 0x0b, 0x1c, 0x17, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x0a,
+          0x0a, 0x0a, 0x0a, 0x0a, 0x0a
+        ]
+      ]
+    end
+
+    context "when number is 0" do
+      let(:number) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Number value 0 is invalid!  Valid number values are 1..8."
+        )
+      end
+    end
+
+    context "when number is 9" do
+      let(:number) { 9 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Number value 9 is invalid!  Valid number values are 1..8."
+        )
+      end
+    end
+
+    context "when status is :armed" do
+      let(:status) { :armed }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x16, 0x0b, 0x1c, 0x17, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x0a,
+          0x0a, 0x0a, 0x0a, 0x0a, 0x0a
+        ]
+      ]
+    end
+
+    context "when status is :unused" do
+      let(:status) { :unused }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x00, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x16, 0x0b, 0x1c, 0x17, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x0a,
+          0x0a, 0x0a, 0x0a, 0x0a, 0x0a
+        ]
+      ]
+    end
+
+    context "when status is :an_invalid_symbol" do
+      let(:status) { :invalid_status}
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Status invalid_status is invalid!  Valid date formats are [:disarmed, :armed, :unused]."
+        )
+      end
+    end
+
+    context "when time is 16:35" do
+      let(:time) { Time.new(0, 1, 1, 16, 35) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x10, 0x23, 0x00, 0x00, 0x00, 0x0b, 0x16, 0x0b, 0x1c, 0x17, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x0a,
+          0x0a, 0x0a, 0x0a, 0x0a, 0x0a
+        ]
+      ]
+    end
+
+    context "when message is \"Wake Up with More than 16 Characters\"" do
+      let(:message) { "Wake Up with More than 16 Characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x0b, 0x15, 0x0f, 0x0a, 0x1f, 0x1a, 0x0a, 0x21, 0x13, 0x1e,
+          0x12, 0x0a, 0x17, 0x19, 0x1c
+        ]
+      ]
+    end
+
+    context "when message is \"()*+,-./:;<=>?@[\\\"" do
+      let(:message) { "()*+,-./:;<=>?@[\\\"" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+          0x37, 0x38, 0x39, 0x3a, 0x3b
+        ]
+      ]
+    end
+
+    context "when message is \"¢with¢invalid¢characters\"" do
+      let(:message) { "¢with¢invalid¢characters" }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x21, 0x13, 0x1e, 0x12, 0x0a, 0x13, 0x18, 0x20, 0x0b, 0x16,
+          0x13, 0x0e, 0x0a, 0x0d, 0x12
+        ]
+      ]
+    end
+
+    context "when month is 2" do
+      let(:month) { 2 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0x0b, 0x16, 0x0b, 0x1c, 0x17, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x0a,
+          0x0a, 0x0a, 0x0a, 0x0a, 0x0a
+        ]
+      ]
+
+      context "when day is 30" do
+        let(:day) { 30 }
+
+        it do
+          expect { packets }.to raise_error(
+            ActiveModel::ValidationError,
+            "Validation failed: Day 30 is invalid for month 2!  Valid days are 1..29 and nil when month is 2."
+          )
+        end
+      end
+    end
+
+    context "when month is 0" do
+      let(:month) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Month 0 is invalid!  Valid months are 1..12 and nil."
+        )
+      end
+    end
+
+    context "when month is 13" do
+      let(:month) { 13 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Month 13 is invalid!  Valid months are 1..12 and nil."
+        )
+      end
+    end
+
+    context "when day is 25" do
+      let(:day) { 25 }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [
+          0x51, 0x01, 0x00, 0x00, 0x00, 0x19, 0x00, 0x0b, 0x16, 0x0b, 0x1c, 0x17, 0x0a, 0x01, 0x0a, 0x0a, 0x0a, 0x0a,
+          0x0a, 0x0a, 0x0a, 0x0a, 0x0a
+        ]
+      ]
+    end
+
+    context "when day is 0" do
+      let(:day) { 0 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Day 0 is invalid!  Valid days are 1..31 and nil."
+        )
+      end
+    end
+
+    context "when day is 32" do
+      let(:day) { 32 }
+
+      it do
+        expect { packets }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Day 32 is invalid!  Valid days are 1..31 and nil."
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/timex_datalink_client/protocol_6/alarm_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/alarm_spec.rb
@@ -87,7 +87,7 @@ describe TimexDatalinkClient::Protocol6::Alarm do
     end
 
     context "when status is :an_invalid_symbol" do
-      let(:status) { :invalid_status}
+      let(:status) { :invalid_status }
 
       it do
         expect { packets }.to raise_error(

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -63,6 +63,7 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_4/time.rb",
     "lib/timex_datalink_client/protocol_4/wrist_app.rb",
 
+    "lib/timex_datalink_client/protocol_6/alarm.rb",
     "lib/timex_datalink_client/protocol_6/end.rb",
     "lib/timex_datalink_client/protocol_6/night_mode_options.rb",
     "lib/timex_datalink_client/protocol_6/pager_options.rb",


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/259! :tada: 

This PR adds Protocol6::Alarm!  Use it like this:

```ruby
models = [
  TimexDatalinkClient::Protocol6::Sync.new,
  TimexDatalinkClient::Protocol6::Start.new,
  TimexDatalinkClient::Protocol6::Alarm.new(
    number: 1,
    status: :armed,
    time: Time.new(0, 1, 1, 16, 35),  # Year, month, and day is ignored.
    message: "Alarm 1",
    month: 10,
    day: 5
  ),
  TimexDatalinkClient::Protocol6::End.new
]

client = TimexDatalinkClient.new(
  serial_device: "/dev/ttyACM0",
  models: models
)

client.write
```

Here's what this looks like in the first-party software:

![image](https://user-images.githubusercontent.com/820984/213978401-492881db-9b8e-4472-9312-a1e286cde416.png)

![image](https://user-images.githubusercontent.com/820984/213978424-f7f0ca66-ff0b-4563-853d-e4e8ea73c436.png)