### PR TITLE
Fix missing period at the end of some YARDoc descriptions

### DIFF
--- a/lib/timex_datalink_client/protocol_1/time_name.rb
+++ b/lib/timex_datalink_client/protocol_1/time_name.rb
@@ -24,7 +24,7 @@ class TimexDatalinkClient
       # Create a TimeName instance.
       #
       # @param zone [Integer] Time zone number (1 or 2).
-      # @param name [String] Name of time zone (3 chars max)
+      # @param name [String] Name of time zone (3 chars max).
       # @return [TimeName] TimeName instance.
       def initialize(zone:, name:)
         @zone = zone

--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -42,7 +42,7 @@ class TimexDatalinkClient
       # @param date_format ["%_m-%d-%y", "%_d-%m-%y", "%y-%m-%d", "%_m.%d.%y", "%_d.%m.%y", "%y.%m.%d"] Date format
       #   (represented by Time#strftime format).
       # @param time [::Time] Time to set (including time zone).
-      # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max)
+      # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max).
       # @return [Time] Time instance.
       def initialize(zone:, is_24h:, date_format:, time:, name: nil)
         @zone = zone

--- a/lib/timex_datalink_client/protocol_4/time.rb
+++ b/lib/timex_datalink_client/protocol_4/time.rb
@@ -42,7 +42,7 @@ class TimexDatalinkClient
       # @param date_format ["%_m-%d-%y", "%_d-%m-%y", "%y-%m-%d", "%_m.%d.%y", "%_d.%m.%y", "%y.%m.%d"] Date format
       #   (represented by Time#strftime format).
       # @param time [::Time] Time to set (including time zone).
-      # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max)
+      # @param name [String, nil] Name of time zone (defaults to zone from time; 3 chars max).
       # @return [Time] Time instance.
       def initialize(zone:, is_24h:, date_format:, time:, name: nil)
         @zone = zone

--- a/lib/timex_datalink_client/protocol_9/time_name.rb
+++ b/lib/timex_datalink_client/protocol_9/time_name.rb
@@ -24,7 +24,7 @@ class TimexDatalinkClient
       # Create a TimeName instance.
       #
       # @param zone [Integer] Time zone number (1 or 2).
-      # @param name [String] Name of time zone (3 chars max)
+      # @param name [String] Name of time zone (3 chars max).
       # @return [TimeName] TimeName instance.
       def initialize(zone:, name:)
         @zone = zone


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/274! :bug: 

This :pinching_hand: PR adds missing periods to the end of some YARDoc descriptions.