### PR TITLE
Fix spec description for Protocol6::NightModeOptions spec

### DIFF
--- a/spec/lib/timex_datalink_client/protocol_6/night_mode_options_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/night_mode_options_spec.rb
@@ -38,7 +38,7 @@ describe TimexDatalinkClient::Protocol6::NightModeOptions do
       end
     end
 
-    context "when indiglo_timeout_seconds is 19" do
+    context "when indiglo_timeout_seconds is 10" do
       let(:indiglo_timeout_seconds) { 10 }
 
       it_behaves_like "CRC-wrapped packets", [[0x72, 0x00, 0x08, 0x0a]]


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/276!

This tiny PR updates a spec description in a Protocol6::NightModeOptions spec description to reflect the value being tested.