### PR TITLE
Fix protocol 3 and 4 date format typo

### DIFF
--- a/docs/timex_datalink_protocol_3.md
+++ b/docs/timex_datalink_protocol_3.md
@@ -137,7 +137,7 @@ TimexDatalinkClient::Protocol3::Time.new(
 )
 ```
 
-Here are the valid values for `action_at_end`, represented by
+Here are the valid values for `date_format`, represented by
 [Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2023-09-06 in `%Y-%m-%d`
 format:
 

--- a/docs/timex_datalink_protocol_4.md
+++ b/docs/timex_datalink_protocol_4.md
@@ -137,7 +137,7 @@ TimexDatalinkClient::Protocol4::Time.new(
 )
 ```
 
-Here are the valid values for `action_at_end`, represented by
+Here are the valid values for `date_format`, represented by
 [Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2023-09-06 in `%Y-%m-%d`
 format:
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/280!

This PR addresses an incorrect reference to `date_format` as `action_at_end`.

From https://github.com/synthead/timex_datalink_client/issues/280:

> 
> Here is the protocol 3 documentation for "Time Settings":
> 
> https://github.com/synthead/timex_datalink_client/blob/349adf628a82a81dfbcc410da6085023892cec9e/docs/timex_datalink_protocol_3.md#L118-L151
> 
> And in markdown:
> 
> > ## Time Settings
> > 
> > ![image](https://user-images.githubusercontent.com/820984/190338907-7fd94480-5898-4e46-b715-56565293d0c8.png)
> > 
> > ```ruby
> > TimexDatalinkClient::Protocol3::Time.new(
> >   zone: 1,
> >   name: "PDT",
> >   time: Time.new(2022, 9, 5, 3, 39, 44),
> >   is_24h: false,
> >   date_format: "%_m-%d-%y"
> > )
> > 
> > TimexDatalinkClient::Protocol3::Time.new(
> >   zone: 2,
> >   name: "GMT",
> >   time: Time.new(2022, 9, 5, 11, 39, 44),
> >   is_24h: true,
> >   date_format: "%_m-%d-%y"
> > )
> > ```
> > 
> > Here are the valid values for `action_at_end`, represented by
> > [Time#strftime format](https://apidock.com/ruby/DateTime/strftime), followed by an example of 2023-09-06 in `%Y-%m-%d`
> > format:
> > 
> > |`date_format` value|Formatted example|
> > |---|---|
> > |`"%_m-%d-%y"`|` 9-06-23`|
> > |`"%_d-%m-%y"`|` 6-09-23`|
> > |`"%y-%m-%d"`|`23-09-06`|
> > |`"%_m.%d.%y"`|` 9.06.23`|
> > |`"%_d.%m.%y"`|` 6.09.23`|
> > |`"%y.%m.%d"`|`23.09.06`|
> 
> This bit:
> 
> > Here are the valid values for `action_at_end`, represented by
> 
> ...should read:
> 
> > Here are the valid values for `date_format`, represented by
> 
> This typo appears in the protocol 3 documentation and the protocol 4 documentation.