### PR TITLE
Explicitly call mode button MODE in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ You're done!  From here, continue reading the documentation for which protocol t
 
 ## Determining the protocol to use
 
-On Timex Datalink watches, pressing the center button on the right will change its mode.  Press this button until "COMM
-MODE" is displayed, then "COMM READY" will appear.  This is sometimes accompanied by a version number.  Use the table
-below to identify the protocol.
+On Timex Datalink watches, press the MODE button until "COMM MODE" is displayed.  "COMM READY" will appear.  This is
+sometimes accompanied by a version number.  Use the table below to identify the protocol.
 
 <table>
   <tr>


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/263!

The README.md states this in the "Determining the protocol to use" section:

> On Timex Datalink watches, pressing the center button on the right will change its mode.  Press this button until "COMM MODE" is displayed, then "COMM READY" will appear.  

In almost every Datalink watch, the mode button is on the right, like so:

![image](https://github.com/synthead/timex_datalink_client/assets/820984/b31a3362-5e1e-4717-83ed-fdabb919d88d)

However, the Motorola Beepwear Pro has the mode button on the left:

![image](https://github.com/synthead/timex_datalink_client/assets/820984/c94ec2e1-b64d-4930-bca0-ee88bf98b9f1)

This PR changes this language to explicitly say to press the MODE button instead of mentioning the button's location:

> On Timex Datalink watches, press the MODE button until "COMM MODE" is displayed.  "COMM READY" will appear.