### PR TITLE
Fix missing aesthetic quote in spec descriptions

### DIFF
--- a/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
@@ -58,7 +58,7 @@ describe TimexDatalinkClient::Protocol1::TimeName do
       ]
     end
 
-    context "when name is \"<>[" do
+    context "when name is \"<>[\"" do
       let(:name) { "<>[" }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -136,7 +136,7 @@ describe TimexDatalinkClient::Protocol3::Time do
       ]
     end
 
-    context "when name is \"<>[" do
+    context "when name is \"<>[\"" do
       let(:name) { "<>[" }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
@@ -136,7 +136,7 @@ describe TimexDatalinkClient::Protocol4::Time do
       ]
     end
 
-    context "when name is \"<>[" do
+    context "when name is \"<>[\"" do
       let(:name) { "<>[" }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
@@ -398,7 +398,7 @@ describe TimexDatalinkClient::Protocol6::Time do
       ]
     end
 
-    context "when name is \"<>[" do
+    context "when name is \"<>[\"" do
       let(:name) { "<>[" }
 
       it_behaves_like "CRC-wrapped packets", [

--- a/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
@@ -58,7 +58,7 @@ describe TimexDatalinkClient::Protocol9::TimeName do
       ]
     end
 
-    context "when name is \"<>[" do
+    context "when name is \"<>[\"" do
       let(:name) { "<>[" }
 
       it_behaves_like "CRC-wrapped packets", [


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/285!

Adds some missing aesthetic quotes to some spec descriptions :+1: 