### PR TITLE
Use TZ1 and TZ2 when no name or time zone is present

### DIFF
--- a/lib/timex_datalink_client/protocol_1/time_name.rb
+++ b/lib/timex_datalink_client/protocol_1/time_name.rb
@@ -49,8 +49,12 @@ class TimexDatalinkClient
 
       private
 
+      def name_formatted
+        name || "tz#{zone}"
+      end
+
       def name_characters
-        chars_for(name, length: 3, pad: true)
+        chars_for(name_formatted, length: 3, pad: true)
       end
     end
   end

--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -33,7 +33,7 @@ class TimexDatalinkClient
         message: "%{value} is invalid!  Valid date formats are #{DATE_FORMAT_MAP.keys}."
       }
 
-      attr_accessor :zone, :is_24h, :date_format, :time
+      attr_accessor :zone, :is_24h, :date_format, :time, :name
 
       # Create a Time instance.
       #
@@ -79,12 +79,12 @@ class TimexDatalinkClient
 
       private
 
-      def name
-        @name || time.zone || "tz#{zone}"
+      def name_formatted
+        name || time.zone || "tz#{zone}"
       end
 
       def name_characters
-        chars_for(name, length: 3, pad: true)
+        chars_for(name_formatted, length: 3, pad: true)
       end
 
       def year_mod_1900

--- a/lib/timex_datalink_client/protocol_3/time.rb
+++ b/lib/timex_datalink_client/protocol_3/time.rb
@@ -80,7 +80,7 @@ class TimexDatalinkClient
       private
 
       def name
-        @name || time.zone.downcase
+        @name || time.zone || "tz#{zone}"
       end
 
       def name_characters

--- a/lib/timex_datalink_client/protocol_4/time.rb
+++ b/lib/timex_datalink_client/protocol_4/time.rb
@@ -33,7 +33,7 @@ class TimexDatalinkClient
         message: "%{value} is invalid!  Valid date formats are #{DATE_FORMAT_MAP.keys}."
       }
 
-      attr_accessor :zone, :is_24h, :date_format, :time
+      attr_accessor :zone, :is_24h, :date_format, :time, :name
 
       # Create a Time instance.
       #
@@ -79,12 +79,12 @@ class TimexDatalinkClient
 
       private
 
-      def name
-        @name || time.zone || "tz#{zone}"
+      def name_formatted
+        name || time.zone || "tz#{zone}"
       end
 
       def name_characters
-        chars_for(name, length: 3, pad: true)
+        chars_for(name_formatted, length: 3, pad: true)
       end
 
       def year_mod_1900

--- a/lib/timex_datalink_client/protocol_4/time.rb
+++ b/lib/timex_datalink_client/protocol_4/time.rb
@@ -80,7 +80,7 @@ class TimexDatalinkClient
       private
 
       def name
-        @name || time.zone.downcase
+        @name || time.zone || "tz#{zone}"
       end
 
       def name_characters

--- a/lib/timex_datalink_client/protocol_6/time.rb
+++ b/lib/timex_datalink_client/protocol_6/time.rb
@@ -161,10 +161,7 @@ class TimexDatalinkClient
       end
 
       def formatted_name
-        return name if name
-        return time.zone if time.zone
-
-        "tz#{zone}"
+        name || time.zone || "tz#{zone}"
       end
 
       def name_characters

--- a/lib/timex_datalink_client/protocol_6/time.rb
+++ b/lib/timex_datalink_client/protocol_6/time.rb
@@ -164,7 +164,7 @@ class TimexDatalinkClient
         return name if name
         return time.zone if time.zone
 
-        "TZ#{zone}"
+        "tz#{zone}"
       end
 
       def name_characters

--- a/lib/timex_datalink_client/protocol_9/time_name.rb
+++ b/lib/timex_datalink_client/protocol_9/time_name.rb
@@ -49,8 +49,12 @@ class TimexDatalinkClient
 
       private
 
+      def name_formatted
+        name || "tz#{zone}"
+      end
+
       def name_characters
-        chars_for(name, length: 3, pad: true)
+        chars_for(name_formatted, length: 3, pad: true)
       end
     end
   end

--- a/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_1/time_name_spec.rb
@@ -73,5 +73,21 @@ describe TimexDatalinkClient::Protocol1::TimeName do
         [0x31, 0x01, 0x15, 0x18, 0x17]
       ]
     end
+
+    context "when name is nil" do
+      let(:name) { nil }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x1d, 0x23, 0x01]
+      ]
+
+      context "when zone is 2" do
+        let(:zone) { 2 }
+
+        it_behaves_like "CRC-wrapped packets", [
+          [0x31, 0x02, 0x1d, 0x23, 0x02]
+        ]
+      end
+    end
   end
 end

--- a/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_3/time_spec.rb
@@ -128,6 +128,22 @@ describe TimexDatalinkClient::Protocol3::Time do
       ]
     end
 
+    context "when time does not contain a time zone" do
+      let(:time) { Time.new(1997, 9, 19, 19, 36, 55, 0) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x37, 0x13, 0x24, 0x09, 0x13, 0x61, 0x1d, 0x23, 0x01, 0x04, 0x01, 0x00]
+      ]
+
+      context "when zone is 2" do
+        let(:zone) { 2 }
+
+        it_behaves_like "CRC-wrapped packets", [
+          [0x32, 0x02, 0x37, 0x13, 0x24, 0x09, 0x13, 0x61, 0x1d, 0x23, 0x02, 0x04, 0x01, 0x00]
+        ]
+      end
+    end
+
     context "when name is \"1\"" do
       let(:name) { "1" }
 

--- a/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_4/time_spec.rb
@@ -128,6 +128,22 @@ describe TimexDatalinkClient::Protocol4::Time do
       ]
     end
 
+    context "when time does not contain a time zone" do
+      let(:time) { Time.new(1997, 9, 19, 19, 36, 55, 0) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x37, 0x13, 0x24, 0x09, 0x13, 0x61, 0x1d, 0x23, 0x01, 0x04, 0x01, 0x00]
+      ]
+
+      context "when zone is 2" do
+        let(:zone) { 2 }
+
+        it_behaves_like "CRC-wrapped packets", [
+          [0x32, 0x02, 0x37, 0x13, 0x24, 0x09, 0x13, 0x61, 0x1d, 0x23, 0x02, 0x04, 0x01, 0x00]
+        ]
+      end
+    end
+
     context "when name is \"1\"" do
       let(:name) { "1" }
 

--- a/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
@@ -390,6 +390,22 @@ describe TimexDatalinkClient::Protocol6::Time do
       ]
     end
 
+    context "when time does not contain a time zone" do
+      let(:time) { Time.new(1997, 9, 19, 19, 36, 55, 0) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x37, 0x13, 0x24, 0x09, 0x13, 0x61, 0x1e, 0x24, 0x01, 0x04, 0x00, 0x01, 0x00]
+      ]
+
+      context "when zone is 2" do
+        let(:zone) { 2 }
+
+        it_behaves_like "CRC-wrapped packets", [
+          [0x32, 0x02, 0x37, 0x13, 0x24, 0x09, 0x13, 0x61, 0x1e, 0x24, 0x02, 0x04, 0x00, 0x01, 0x00]
+        ]
+      end
+    end
+
     context "when name is \"1\"" do
       let(:name) { "1" }
 

--- a/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_9/time_name_spec.rb
@@ -73,5 +73,21 @@ describe TimexDatalinkClient::Protocol9::TimeName do
         [0x31, 0x01, 0x15, 0x18, 0x17]
       ]
     end
+
+    context "when name is nil" do
+      let(:name) { nil }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x31, 0x01, 0x1d, 0x23, 0x01]
+      ]
+
+      context "when zone is 2" do
+        let(:zone) { 2 }
+
+        it_behaves_like "CRC-wrapped packets", [
+          [0x31, 0x02, 0x1d, 0x23, 0x02]
+        ]
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/266!

In `Time` for protocols 3 and 4, if `name` is `nil`, and `time` does not have a time zone, no implicit time zone name is built, and an obscure exception is raised: undefined method `downcase' for nil:NilClass.  For `TimeName` in protocols 1 and 9, if `name` is `nil`, then the same exception is raised, also.

This PR fixes this issue and uses TZ1 or TZ2 for the time zone name based on the time zone number.  This is the default behavior of the Timex Datalink watches, so this should already be expected behavior :+1: 