### PR TITLE
Use more explicit explanation of how a CRT works in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ models (supported by this software) have an optical sensor on the top of the fac
 
 The original data transfer method involves
 [drawing patterns of lines on a CRT monitor](https://www.youtube.com/watch?v=p3Pzxmq-JLM) for the watch to receive with
-the optical sensor.  CRTs use electron guns that draw scan lines one-by-one from top to bottom, then they return to the
+its optical sensor.  CRTs use electron guns that draw scan lines one-by-one from top to bottom, then they return to the
 top in preparation for the next frame.  This means that the electron guns turn on when they're drawing a white line, and
 and turn off when they're drawing the black background.  This produces flashing light as the graphics are drawn, which
 is ultimately received by the optical sensor and decoded by the Timex Datalink device.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ models (supported by this software) have an optical sensor on the top of the fac
 
 The original data transfer method involves
 [drawing patterns of lines on a CRT monitor](https://www.youtube.com/watch?v=p3Pzxmq-JLM) for the watch to receive with
-the optical sensor.  CRTs use electron beams that draw scan lines one-by-one from top to bottom, then it returns to the
-top and repeats for the next frame. This means that the electron guns turn on when its drawing a white line, and and
-turn off when its drawing the black background. This produces flashing light as the graphics are drawn, which is
-ultimately received by the optical sensor and decoded by the Timex Datalink device.
+the optical sensor.  CRTs use electron guns that draw scan lines one-by-one from top to bottom, then they return to the
+top in preparation for the next frame.  This means that the electron guns turn on when they're drawing a white line, and
+and turn off when they're drawing the black background.  This produces flashing light as the graphics are drawn, which
+is ultimately received by the optical sensor and decoded by the Timex Datalink device.
 
 Have a CRT monitor?  Use this library with [timex\_datalink\_crt](https://github.com/synthead/timex_datalink_crt) to
 transfer data with your CRT!


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/293!

This PR replaces this text in README.md:

> The original data transfer method involves [drawing patterns of lines on a CRT monitor](https://www.youtube.com/watch?v=p3Pzxmq-JLM) for the watch to receive with the optical sensor. CRTs use electron beams that draw scan lines one-by-one from top to bottom, then it returns to the top and repeats for the next frame. This means that the electron guns turn on when its drawing a white line, and and turn off when its drawing the black background. This produces flashing light as the graphics are drawn, which is ultimately received by the optical sensor and decoded by the Timex Datalink device.

...with:

> The original data transfer method involves [drawing patterns of lines on a CRT monitor](https://www.youtube.com/watch?v=p3Pzxmq-JLM) for the watch to receive with its optical sensor. CRTs use electron guns that draw scan lines one-by-one from top to bottom, then they return to the top in preparation for the next frame. This means that the electron guns turn on when they're drawing a white line, and and turn off when they're drawing the black background. This produces flashing light as the graphics are drawn, which is ultimately received by the optical sensor and decoded by the Timex Datalink device.