### PR TITLE
Fix inconsistent Timer example in protocol 9 documentation

### DIFF
--- a/docs/timex_ironman_triathlon_protocol_9.md
+++ b/docs/timex_ironman_triathlon_protocol_9.md
@@ -77,7 +77,7 @@ TimexDatalinkClient::Protocol9::Timer.new(
 TimexDatalinkClient::Protocol9::Timer.new(
   number: 4,
   label: "TIMER 4",
-  time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
+  time: Time.new(0, 1, 1, 0, 30, 0),  # Year, month, and day is ignored.
   action_at_end: :stop_timer
 )
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/299!

This PR fixes a small inconsistency in the protocol 9 documentation for protocol 9.

From https://github.com/synthead/timex_datalink_client/issues/299:

> The fourth Timer example in the protocol 9 documentation graphic shows 0:30, but the fourth Timer model in the code example shows 1:30:
> 
> > ## Timers
> > 
> > ![image](https://user-images.githubusercontent.com/820984/190354187-f1b7747e-003a-490f-b1e7-7869485b1fee.png)
> > 
> > ```ruby
> > TimexDatalinkClient::Protocol9::Timer.new(
> >   number: 1,
> >   label: "TIMER 1",
> >   time: Time.new(0, 1, 1, 0, 5, 0),  # Year, month, and day is ignored.
> >   action_at_end: :stop_timer
> > )
> > 
> > TimexDatalinkClient::Protocol9::Timer.new(
> >   number: 2,
> >   label: "TIMER 2",
> >   time: Time.new(0, 1, 1, 0, 10, 0),  # Year, month, and day is ignored.
> >   action_at_end: :repeat_timer
> > )
> > 
> > TimexDatalinkClient::Protocol9::Timer.new(
> >   number: 3,
> >   label: "TIMER 3",
> >   time: Time.new(0, 1, 1, 0, 15, 0),  # Year, month, and day is ignored.
> >   action_at_end: :repeat_timer
> > )
> > 
> > TimexDatalinkClient::Protocol9::Timer.new(
> >   number: 4,
> >   label: "TIMER 4",
> >   time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
> >   action_at_end: :stop_timer
> > )
> > 
> > TimexDatalinkClient::Protocol9::Timer.new(
> >   number: 5,
> >   label: "TIMER 5",
> >   time: Time.new(0, 1, 1, 1, 0, 0),  # Year, month, and day is ignored.
> >   action_at_end: :start_chrono
> > )
> > ```