### PR TITLE
Use identical Timer examples in complete code example for protocol 9

### DIFF
--- a/docs/timex_ironman_triathlon_protocol_9.md
+++ b/docs/timex_ironman_triathlon_protocol_9.md
@@ -284,7 +284,7 @@ models = [
   TimexDatalinkClient::Protocol9::Timer.new(
     number: 4,
     label: "TIMER 4",
-    time: Time.new(0, 1, 1, 1, 30, 0),  # Year, month, and day is ignored.
+    time: Time.new(0, 1, 1, 0, 30, 0),  # Year, month, and day is ignored.
     action_at_end: :stop_timer
   ),
   TimexDatalinkClient::Protocol9::Timer.new(


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/301!

From https://github.com/synthead/timex_datalink_client/issues/301:

> This is the documentation for protocol 9's Timer models:
> 
> https://github.com/synthead/timex_datalink_client/blob/80ef9e7f344801d77a8fb483dcb223bdd54767d5/docs/timex_ironman_triathlon_protocol_9.md#L51-L90
> 
> The above uses 0:30 for the fourth item, but in the complete code example, it uses 1:30:
> 
> https://github.com/synthead/timex_datalink_client/blob/80ef9e7f344801d77a8fb483dcb223bdd54767d5/docs/timex_ironman_triathlon_protocol_9.md#L266-L295
> 
> These should probably be the same for consistency :+1: 