### PR TITLE
Fix inconsistency in protocol 7 documentation's phone numbers

### DIFF
--- a/docs/dsi_ebrain_protocol_7.md
+++ b/docs/dsi_ebrain_protocol_7.md
@@ -122,7 +122,7 @@ TimexDatalinkClient::Protocol7::Eeprom.new(calendar: calendar)
 phrase_builder = TimexDatalinkClient::Protocol7::PhraseBuilder.new(database: "pcvocab.mdb")
 
 dog_sitter = phrase_builder.vocab_ids_for("Dog", "Sitter")
-mom_and_dad = phrase_builder.vocab_ids_for("Mom", "And", "Dad")
+ebrain_mom_and_dad = phrase_builder.vocab_ids_for("eBrain", "Mom", "And", "Dad")
 
 phone_numbers = [
   TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber.new(
@@ -130,7 +130,7 @@ phone_numbers = [
     number: "8675309"
   ),
   TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber.new(
-    name: mom_and_dad,
+    name: ebrain_mom_and_dad,
     number: "7133659900"
   )
 ]
@@ -239,7 +239,7 @@ calendar = TimexDatalinkClient::Protocol7::Eeprom::Calendar.new(
 )
 
 dog_sitter = phrase_builder.vocab_ids_for("Dog", "Sitter")
-mom_and_dad = phrase_builder.vocab_ids_for("Mom", "And", "Dad")
+ebrain_mom_and_dad = phrase_builder.vocab_ids_for("eBrain", "Mom", "And", "Dad")
 
 phone_numbers = [
   TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber.new(
@@ -247,7 +247,7 @@ phone_numbers = [
     number: "8675309"
   ),
   TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber.new(
-    name: mom_and_dad,
+    name: ebrain_mom_and_dad,
     number: "7133659900"
   )
 ]


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/303!

This PR fixes an inconsistency in the protocol 7 documentation where a phone number name in the screenshot uses "eBrain Mom And Dad", but the example code uses "Mom And Dad".

From https://github.com/synthead/timex_datalink_client/issues/303:

> This is in the documentation for protocol 7 phone numbers:
> 
> > ## Phone Numbers
> > 
> > ![image](https://user-images.githubusercontent.com/820984/207311988-ff21dc2e-2530-4437-a6fa-93e7c24be591.png)
> > 
> > ```ruby
> > phrase_builder = TimexDatalinkClient::Protocol7::PhraseBuilder.new(database: "pcvocab.mdb")
> > 
> > dog_sitter = phrase_builder.vocab_ids_for("Dog", "Sitter")
> > mom_and_dad = phrase_builder.vocab_ids_for("Mom", "And", "Dad")
> > 
> > phone_numbers = [
> >   TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber.new(
> >     name: dog_sitter,
> >     number: "8675309"
> >   ),
> >   TimexDatalinkClient::Protocol7::Eeprom::PhoneNumber.new(
> >     name: mom_and_dad,
> >     number: "7133659900"
> >   )
> > ]
> > 
> > TimexDatalinkClient::Protocol7::Eeprom.new(phone_numbers: phone_numbers)
> > ```
> 
> The second name in the example is "eBrain Mom And Dad", but the example only uses "Mom And Dad".