### PR TITLE
Use clearer documentation for unsupported WristApp and Watch Sounds in protocol 1

### DIFF
--- a/docs/timex_datalink_protocol_1.md
+++ b/docs/timex_datalink_protocol_1.md
@@ -5,8 +5,10 @@ software version 2.1d.
 
 ![image](https://user-images.githubusercontent.com/820984/190341990-540fd072-4380-4c01-b5d4-5f2f2b78950f.png)
 
-Please note that WristApps and Watch Sounds are not supported in protocol 1.  They are visible in the Timex Datalink
-software, but when the buttons are clicked, it will display a dialog about the feature is not supported.
+Please note that WristApps and Watch Sounds are not supported in protocol 1, even though buttons are visible for them in
+the Timex Datalink software when protocol 1 is configured.  When these buttons are clicked, it will display
+[a dialog box about how the feature is not supported](
+https://github.com/synthead/timex_datalink_client/assets/820984/62520403-2943-4a41-8256-631fada3a5b7).
 
 ## Appointments
 


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_client/issues/311!

This PR updates the second paragraph in the protocol 1 documentation to use clearer language about how the WristApp and Watch Sounds buttons in the original software will not work with protocol 1 devices.

Includes a link to a screenshot of the error displayed when the WristApp button is clicked.