### PR TITLE
Use SerialPort for serial interaction (fixes semaphore timeouts in Windows)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activemodel (~> 7.0.4)
       crc (~> 0.4.2)
       mdb (~> 0.5.0)
-      rubyserial (~> 0.6.0)
+      serialport (~> 1.3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -24,7 +24,6 @@ GEM
     concurrent-ruby (1.2.2)
     crc (0.4.2)
     diff-lcs (1.5.0)
-    ffi (1.15.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
@@ -93,8 +92,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
-    rubyserial (0.6.0)
-      ffi (~> 1.9, >= 1.9.3)
+    serialport (1.3.2)
     tomlrb (2.0.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/lib/timex_datalink_client/notebook_adapter.rb
+++ b/lib/timex_datalink_client/notebook_adapter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rubyserial"
+require "serialport"
 
 class TimexDatalinkClient
   class NotebookAdapter
@@ -32,7 +32,7 @@ class TimexDatalinkClient
         packet.each do |byte|
           printf("%.2X ", byte) if verbose
 
-          serial.write(byte.chr)
+          serial_port.write(byte.chr)
 
           sleep(byte_sleep)
         end
@@ -45,8 +45,8 @@ class TimexDatalinkClient
 
     private
 
-    def serial
-      @serial ||= Serial.new(serial_device)
+    def serial_port
+      @serial_port ||= SerialPort.new(serial_device)
     end
   end
 end

--- a/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
+++ b/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
@@ -25,10 +25,10 @@ describe TimexDatalinkClient::NotebookAdapter do
       ]
     end
 
-    let(:serial_double) { instance_double(Serial) }
+    let(:serial_double) { instance_double(SerialPort) }
 
     it "writes serial data with correct sleep lengths" do
-      expect(Serial).to receive(:new).with(serial_device).and_return(serial_double)
+      expect(SerialPort).to receive(:new).with(serial_device).and_return(serial_double)
 
       packets.each do |packet|
         packet.each do |byte|
@@ -43,7 +43,7 @@ describe TimexDatalinkClient::NotebookAdapter do
     end
 
     it "does not write to console" do
-      allow(Serial).to receive(:new).with(serial_device).and_return(serial_double)
+      allow(SerialPort).to receive(:new).with(serial_device).and_return(serial_double)
       allow(serial_double).to receive(:write)
       allow(notebook_adapter).to receive(:sleep)
 
@@ -57,7 +57,7 @@ describe TimexDatalinkClient::NotebookAdapter do
       let(:verbose) { true }
 
       it "writes serial data with console output" do
-        expect(Serial).to receive(:new).with(serial_device).and_return(serial_double)
+        expect(SerialPort).to receive(:new).with(serial_device).and_return(serial_double)
 
         packets.each do |packet|
           packet.each do |byte|

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -102,5 +102,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activemodel", "~> 7.0.4"
   s.add_dependency "crc", "~> 0.4.2"
   s.add_dependency "mdb", "~> 0.5.0"
-  s.add_dependency "rubyserial", "~> 0.6.0"
+  s.add_dependency "serialport", "~> 1.3.2"
 end


### PR DESCRIPTION
https://github.com/synthead/timex_datalink_client/issues/308!

This PR fixes an issue where semaphore timeouts were raised when using timex_datalink_client with Windows 10 using Ruby from [RubyInstaller](https://rubyinstaller.org/):

```
C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/rubyserial-0.6.0/lib/rubyserial/windows.rb:73:in `write': ERROR_SEM_TIMEOUT (RubySerial::Error)
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.1/lib/timex_datalink_client/notebook_adapter.rb:35:in `block (2 levels) in write'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.1/lib/timex_datalink_client/notebook_adapter.rb:32:in `each'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.1/lib/timex_datalink_client/notebook_adapter.rb:32:in `block in write'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.1/lib/timex_datalink_client/notebook_adapter.rb:31:in `each'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.1/lib/timex_datalink_client/notebook_adapter.rb:31:in `write'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.1/lib/timex_datalink_client.rb:113:in `write'
        from ./timexTest.rb:132:in `<main>'
```

With these changes, timex_datalink_client works great under native Windows and Linux :+1: 

The SerialPort library uses the same `#write` method to write data, so the only changes introduced in this PR are for swapping the lib (and a small private method rename).