### PR TITLE
Fix protocol 6 (Beepwear Pro) setting time 1 hour fast in daylight savings time

### DIFF
--- a/lib/timex_datalink_client/protocol_6/time.rb
+++ b/lib/timex_datalink_client/protocol_6/time.rb
@@ -141,23 +141,23 @@ class TimexDatalinkClient
       end
 
       def second
-        flex_time ? 0 : formatted_time.sec
+        flex_time ? 0 : time.sec
       end
 
       def hour
-        flex_time ? 0 : formatted_time.hour
+        flex_time ? 0 : time.hour
       end
 
       def minute
-        flex_time ? 0 : formatted_time.min
+        flex_time ? 0 : time.min
       end
 
       def month
-        flex_time ? 0 : formatted_time.month
+        flex_time ? 0 : time.month
       end
 
       def day
-        flex_time ? 0 : formatted_time.day
+        flex_time ? 0 : time.day
       end
 
       def formatted_name
@@ -169,15 +169,11 @@ class TimexDatalinkClient
       end
 
       def year_mod_1900
-        flex_time ? 0 : formatted_time.year % 100
+        flex_time ? 0 : time.year % 100
       end
 
       def wday_from_monday
-        flex_time ? 0 : (formatted_time.wday + 6) % 7
-      end
-
-      def formatted_time
-        time.dst? ? time + 3600 : time
+        flex_time ? 0 : (time.wday + 6) % 7
       end
 
       def formatted_utc_offset

--- a/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
@@ -133,15 +133,6 @@ describe TimexDatalinkClient::Protocol6::Time do
       ]
     end
 
-    context "when time is in daylight savings time" do
-      let(:tzinfo) { TZInfo::Timezone.get("US/Pacific") }
-      let(:time) { tzinfo.local_time(2015, 10, 21, 19, 28, 32) }
-
-      it_behaves_like "CRC-wrapped packets", [
-        [0x32, 0x01, 0x20, 0x14, 0x1c, 0x0a, 0x15, 0x0f, 0x1a, 0x0e, 0x1e, 0x02, 0x18, 0x01, 0x00]
-      ]
-    end
-
     context "when time has a UTC offset of -11:00" do
       let(:utc_offset) { "-11:00" }
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/309!

This PR fixes a bug where the time on the Beepwear Pro (protocol 6) would be set one hour fast for a time in daylight savings time :bug: 

To determine time zone, the UTC offset is used, which adds one hour during daylight savings.  Due to this, some small logic was added to remove one hour from the UTC offset in daylight savings prior to looking up the protocol 6 time zone for the offset.  The time on the watch naively followed this pattern also, when it didn't need to, which caused this bug.