### PR TITLE
Require Ruby 3.1.0 or greater in gemspec

### DIFF
--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -99,6 +99,8 @@ Gem::Specification.new do |s|
     "lib/timex_datalink_client/protocol_9/timer.rb"
   ]
 
+  s.required_ruby_version = ">= 3.1.0"
+
   s.add_dependency "activemodel", "~> 7.0.4"
   s.add_dependency "crc", "~> 0.4.2"
   s.add_dependency "mdb", "~> 0.5.0"


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/317!

Adds `s.required_ruby_version = ">= 3.1.0"` to require Ruby 3.1.0 or greater, which is the minimum-supported version of this gem.

From https://github.com/synthead/timex_datalink_client/issues/317:

> The [gemspec](https://github.com/synthead/timex_datalink_client/blob/2dde3ccf50b5aacf449de8bfdb489c3de81d26df/timex_datalink_client.gemspec) doesn't specify a minimum Ruby version, and this lib uses omitted keyword arguments, which is a [feature introduced in Ruby 3.1.0](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/):
> 
> > - Values in Hash literals and keyword arguments can be omitted. [[Feature #14579]](https://bugs.ruby-lang.org/issues/14579)
> > 
> >    - `{x:, y:}` is syntax sugar for `{x: x, y: y}`.
> >    - `foo(x:, y:)` is syntax sugar for `foo(x: x, y: y)`.
> 
> This means that it's possible to install the timex_datalink_client gem on a version of Ruby that is too old, i.e. 3.0.6.  When attempting to use the gem on 3.0.6, this exception is raised:
> 
> ```
> <internal:/home/elaine/.rbenv/versions/3.0.6/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': /home/elaine/repos/timex_datalink_client/lib/timex_datalink_client.rb:127: syntax error, unexpected ',' (SyntaxError)
>       serial_device:,
>                     ^
> 	from <internal:/home/elaine/.rbenv/versions/3.0.6/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from examples/protocol_7/clear-data:10:in `<main>'
> ```
> 
> A minimum version of 3.1.0 should be set by adding this to the gemspec:
> 
> ```ruby
> s.required_ruby_version = ">= 3.1.0"
> ```
> 
> This will present a definitive error to the user if they attempt to install this gem on an older version:
> 
> ```
> timex_datalink_client-0.12.3 requires ruby version >= 3.1.0, which is incompatible with the current version, ruby 3.0.6p216
> ```