### PR TITLE
Add Calendar::Event time validation for protocol 7

### DIFF
--- a/lib/timex_datalink_client/protocol_7/eeprom/calendar/event.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/calendar/event.rb
@@ -16,7 +16,7 @@ class TimexDatalinkClient
 
           validates :time, comparison: {
             greater_than_or_equal_to: :device_time,
-            message: "%{value} must be greater than device time!"
+            message: "%{value} must be greater or equal to device time!"
           }
 
           attr_accessor :time, :phrase, :device_time

--- a/lib/timex_datalink_client/protocol_7/eeprom/calendar/event.rb
+++ b/lib/timex_datalink_client/protocol_7/eeprom/calendar/event.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_model"
+
 require "timex_datalink_client/helpers/lsb_msb_formatter"
 
 class TimexDatalinkClient
@@ -7,16 +9,23 @@ class TimexDatalinkClient
     class Eeprom
       class Calendar
         class Event
+          include ActiveModel::Validations
           include Helpers::LsbMsbFormatter
 
           FIVE_MINUTES_SECONDS = 300
 
-          attr_accessor :time, :phrase
+          validates :time, comparison: {
+            greater_than_or_equal_to: :device_time,
+            message: "%{value} must be greater than device time!"
+          }
+
+          attr_accessor :time, :phrase, :device_time
 
           # Create an Event instance.
           #
           # @param time [::Time] Time of event.
           # @param phrase [Array<Integer>] Phrase for event.
+          # @raise [ActiveModel::ValidationError] One or more model values are invalid.
           # @return [Event] Event instance.
           def initialize(time:, phrase:)
             @time = time
@@ -24,6 +33,10 @@ class TimexDatalinkClient
           end
 
           def time_formatted(device_time)
+            @device_time = device_time
+
+            validate!
+
             device_time_midnight = Time.new(device_time.year, device_time.month, device_time.day)
             seconds = (time - device_time_midnight).to_i
             five_minutes = seconds / FIVE_MINUTES_SECONDS

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/calendar/event_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/calendar/event_spec.rb
@@ -45,12 +45,12 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Calendar::Event do
     end
 
     context "when time is 2021-12-10 15:28:15" do
-      let(:time) { Time.new(2021, 12, 23, 18, 30, 20) }
+      let(:time) { Time.utc(2021, 12, 23, 18, 30, 20) }
 
       it do
         expect { phrase_value }.to raise_error(
           ActiveModel::ValidationError,
-          "Validation failed: Time 2021-12-23 18:30:20 -0800 must be greater than device time!"
+          "Validation failed: Time 2021-12-23 18:30:20 UTC must be greater than device time!"
         )
       end
     end

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/calendar/event_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/calendar/event_spec.rb
@@ -50,7 +50,7 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Calendar::Event do
       it do
         expect { phrase_value }.to raise_error(
           ActiveModel::ValidationError,
-          "Validation failed: Time 2021-12-23 18:30:20 UTC must be greater than device time!"
+          "Validation failed: Time 2021-12-23 18:30:20 UTC must be greater or equal to device time!"
         )
       end
     end

--- a/spec/lib/timex_datalink_client/protocol_7/eeprom/calendar/event_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_7/eeprom/calendar/event_spec.rb
@@ -43,5 +43,16 @@ describe TimexDatalinkClient::Protocol7::Eeprom::Calendar::Event do
 
       it { should eq([0x7e, 0x0f]) }
     end
+
+    context "when time is 2021-12-10 15:28:15" do
+      let(:time) { Time.new(2021, 12, 23, 18, 30, 20) }
+
+      it do
+        expect { phrase_value }.to raise_error(
+          ActiveModel::ValidationError,
+          "Validation failed: Time 2021-12-23 18:30:20 -0800 must be greater than device time!"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/321!

This PR adds an ActiveRecord validation for protocol 7's Calendar::Event's time value to ensure no events are before the device time.  Due to protocol limitations related to event times being relative to the device time, it is not possible to transfer events in the past.

From https://github.com/synthead/timex_datalink_client/issues/321:

> Related to https://github.com/synthead/timex_datalink_client/issues/316.
> 
> The DSI e-BRAIN (protocol 7) uses 5 minute intervals relative to the current date of the device time as the event time.  This means that if the device time is midnight, and the event if at 00:15, the calendar event time is sent as "3".  If the event is midnight on the next day, it is sent as "288" (1440 minutes in a day / 5 minutes).
> 
> Since this is relative to the device time, if a calendar event happens to be before the device time, then this method will produce negative values in its array of bytes:
> 
> https://github.com/synthead/timex_datalink_client/blob/f80d9d1f5f625139fb367bde33a99531b9fa9565/lib/timex_datalink_client/protocol_7/eeprom/calendar/event.rb?plain=1#L26-L32
> 
> When this happens, this exception is seen when attempting a transfer:
> 
> ```
> /home/jac/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.2/lib/timex_datalink_client/notebook_adapter.rb:35:in `chr': -261 out of char range (RangeError)
>         from /home/jac/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.2/lib/timex_datalink_client/notebook_adapter.rb:35:in `block (2 levels) in write'
>         from /home/jac/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.2/lib/timex_datalink_client/notebook_adapter.rb:32:in `each'
>         from /home/jac/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.2/lib/timex_datalink_client/notebook_adapter.rb:32:in `block in write'
>         from /home/jac/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.2/lib/timex_datalink_client/notebook_adapter.rb:31:in `each'
>         from /home/jac/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.2/lib/timex_datalink_client/notebook_adapter.rb:31:in `write'
>         from /home/jac/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.2/lib/timex_datalink_client.rb:113:in `write'
>         from ebrain.ruby:111:in `<main>'
> ```
> 
> Since it is not possible to transfer calendar events in the past on protocol 7 due to the relative time comparison, an ActiveModel validation should be added to protocol 7's Eeprom::Calendar::Event. This will ensure that invalid data is not passed to protocol 7's Eeprom, and ultimately causing exceptions when attempting to pass negative values to TimexDatalinkClient::NotebookAdapter.