### PR TITLE
Use relative times for tomorrow for calendar events in protocol 7 documentation

### DIFF
--- a/docs/dsi_ebrain_protocol_7.md
+++ b/docs/dsi_ebrain_protocol_7.md
@@ -218,17 +218,18 @@ games = TimexDatalinkClient::Protocol7::Eeprom::Games.new(
 )
 
 time = Time.now
+tomorrow = time.to_date + 1
 
 breakfast_with_cousins = phrase_builder.vocab_ids_for("Breakfast", "With", "Cousins")
 crashing_around_the_house = phrase_builder.vocab_ids_for("Crashing", "Around", "The", "House")
 
 events = [
   TimexDatalinkClient::Protocol7::Eeprom::Calendar::Event.new(
-    time: Time.new(time.year, time.month, time.day + 1, 9, 0, 0),
+    time: Time.new(tomorrow.year, tomorrow.month, tomorrow.day, 9, 0, 0),
     phrase: breakfast_with_cousins
   ),
   TimexDatalinkClient::Protocol7::Eeprom::Calendar::Event.new(
-    time: Time.new(time.year, time.month, time.day + 1, 19, 0, 0),
+    time: Time.new(tomorrow.year, tomorrow.month, tomorrow.day, 19, 0, 0),
     phrase: crashing_around_the_house
   )
 ]

--- a/docs/dsi_ebrain_protocol_7.md
+++ b/docs/dsi_ebrain_protocol_7.md
@@ -224,11 +224,11 @@ crashing_around_the_house = phrase_builder.vocab_ids_for("Crashing", "Around", "
 
 events = [
   TimexDatalinkClient::Protocol7::Eeprom::Calendar::Event.new(
-    time: Time.new(2022, 12, 13, 9, 0, 0),
+    time: Time.new(time.year, time.month, time.day + 1, 9, 0, 0),
     phrase: breakfast_with_cousins
   ),
   TimexDatalinkClient::Protocol7::Eeprom::Calendar::Event.new(
-    time: Time.new(2022, 12, 13, 19, 0, 0),
+    time: Time.new(time.year, time.month, time.day + 1, 19, 0, 0),
     phrase: crashing_around_the_house
   )
 ]


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/323!
Related to https://github.com/synthead/timex_datalink_client/issues/316.

This PR replaces the fixed times for calendar events with relative times for tomorrow in the protocol 7 documentation.  This fixes a documentation bug where `Time.now` in the complete code example advances past the fixed calendar event times.

From https://github.com/synthead/timex_datalink_client/issues/323:

> Related to https://github.com/synthead/timex_datalink_client/issues/316.
> Related to https://github.com/synthead/timex_datalink_client/issues/321.
> 
> The DSI e-BRAIN (protocol 7) uses 5 minute intervals relative to the current date of the device time as the event time. This means that if the device time is midnight, and the event if at 00:15, the calendar event time is sent as "3". If the event is midnight on the next day, it is sent as "288" (1440 minutes in a day / 5 minutes).
> 
> Since this is relative to the device time, if a calendar event happens to be before the device time, then the calendar event time will have a negative value due to it being relative to the device time.  With https://github.com/synthead/timex_datalink_client/pull/322, calendar event times are now validated, and a event before the device time will raise a message like so:
> 
> ```
> Validation failed: Time 2022-12-13 09:00:00 -0800 must be greater or equal to device time! (ActiveModel::ValidationError)
> ```
> 
> The protocol 7 documentation includes a combination of `Time.now` for the device time, and two times in December, 2022 as calendar event times:
> 
> https://github.com/synthead/timex_datalink_client/blob/ae4cdb4bc144c594f50753c750f7c11103365a93/docs/dsi_ebrain_protocol_7.md?plain=1#L220-L239
> 
> While the protocol 7 documentation worked well when it was written, time has passed, and the 2022 dates are now before `Time.now`, so the complete code example in the protocol 7 documentation now raises exceptions when used.
> 
> This should be fixed so that the example works at any point in time.  Since the calendar event times are relative to the device time, and the example uses a relative `Time.now` device time, the failure-proof way to fix this documentation would be to make the event examples relative to `Time.now`, too.