### PR TITLE
Add protocol 6 Time spec for time in DST

### DIFF
--- a/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
+++ b/spec/lib/timex_datalink_client/protocol_6/time_spec.rb
@@ -133,6 +133,15 @@ describe TimexDatalinkClient::Protocol6::Time do
       ]
     end
 
+    context "when time is in daylight savings time" do
+      let(:tzinfo) { TZInfo::Timezone.get("US/Pacific") }
+      let(:time) { tzinfo.local_time(2015, 10, 21, 19, 28, 32) }
+
+      it_behaves_like "CRC-wrapped packets", [
+        [0x32, 0x01, 0x20, 0x13, 0x1c, 0x0a, 0x15, 0x0f, 0x1a, 0x0e, 0x1e, 0x02, 0x18, 0x01, 0x00]
+      ]
+    end
+
     context "when time has a UTC offset of -11:00" do
       let(:utc_offset) { "-11:00" }
 


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/325!

This PR adds a spec to ensure that a time in DST is doing what it should.

From https://github.com/synthead/timex_datalink_client/issues/325:

> This PR fixed a bug where the time on the Beepwear Pro (protocol 6) was set one hour fast for a time in daylight savings time:
> 
> - https://github.com/synthead/timex_datalink_client/pull/314
> 
> It removed this spec, since daylight savings time is now handled without any special circumstances:
> 
> https://github.com/synthead/timex_datalink_client/blob/7ca215486e5797b98e2f51be42852857f0db2100/spec/lib/timex_datalink_client/protocol_6/time_spec.rb#L136-L143
> 
> However, it'd still be good to have this spec in place to ensure that it isn't being treated with any special circumstances 👍 