### PR TITLE
Replace serialport gem with uart gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activemodel (~> 7.0.4)
       crc (~> 0.4.2)
       mdb (~> 0.5.0)
-      serialport (~> 1.3.2)
+      uart (~> 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -92,10 +92,12 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
-    serialport (1.3.2)
+    ruby-termios (1.1.0)
     tomlrb (2.0.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uart (1.0.0)
+      ruby-termios
     unicode-display_width (2.4.2)
     yard (0.9.34)
     yard-junk (0.0.9)

--- a/lib/timex_datalink_client/notebook_adapter.rb
+++ b/lib/timex_datalink_client/notebook_adapter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "serialport"
+require "uart"
 
 class TimexDatalinkClient
   class NotebookAdapter
@@ -28,25 +28,21 @@ class TimexDatalinkClient
     # @param packets [Array<Array<Integer>>] Two-dimensional array of integers that represent bytes.
     # @return [void]
     def write(packets)
-      packets.each do |packet|
-        packet.each do |byte|
-          printf("%.2X ", byte) if verbose
+      UART.open(serial_device) do |serial_port|
+        packets.each do |packet|
+          packet.each do |byte|
+            printf("%.2X ", byte) if verbose
 
-          serial_port.write(byte.chr)
+            serial_port.write(byte.chr)
 
-          sleep(byte_sleep)
+            sleep(byte_sleep)
+          end
+
+          sleep(packet_sleep)
+
+          puts if verbose
         end
-
-        sleep(packet_sleep)
-
-        puts if verbose
       end
-    end
-
-    private
-
-    def serial_port
-      @serial_port ||= SerialPort.new(serial_device)
     end
   end
 end

--- a/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
+++ b/spec/lib/timex_datalink_client/notebook_adapter_spec.rb
@@ -25,14 +25,14 @@ describe TimexDatalinkClient::NotebookAdapter do
       ]
     end
 
-    let(:serial_double) { instance_double(SerialPort) }
+    let(:serial_port_double) { instance_double(File) }
 
     it "writes serial data with correct sleep lengths" do
-      expect(SerialPort).to receive(:new).with(serial_device).and_return(serial_double)
+      expect(UART).to receive(:open).with(serial_device).and_yield(serial_port_double)
 
       packets.each do |packet|
         packet.each do |byte|
-          expect(serial_double).to receive(:write).with(byte.chr).ordered
+          expect(serial_port_double).to receive(:write).with(byte.chr).ordered
           expect(notebook_adapter).to receive(:sleep).with(byte_sleep).ordered
         end
 
@@ -43,8 +43,8 @@ describe TimexDatalinkClient::NotebookAdapter do
     end
 
     it "does not write to console" do
-      allow(SerialPort).to receive(:new).with(serial_device).and_return(serial_double)
-      allow(serial_double).to receive(:write)
+      allow(UART).to receive(:open).with(serial_device).and_yield(serial_port_double)
+      allow(serial_port_double).to receive(:write)
       allow(notebook_adapter).to receive(:sleep)
 
       expect(notebook_adapter).to_not receive(:printf)
@@ -57,12 +57,12 @@ describe TimexDatalinkClient::NotebookAdapter do
       let(:verbose) { true }
 
       it "writes serial data with console output" do
-        expect(SerialPort).to receive(:new).with(serial_device).and_return(serial_double)
+        expect(UART).to receive(:open).with(serial_device).and_yield(serial_port_double)
 
         packets.each do |packet|
           packet.each do |byte|
             expect(notebook_adapter).to receive(:printf).with("%.2X ", byte).ordered
-            expect(serial_double).to receive(:write).ordered
+            expect(serial_port_double).to receive(:write).ordered
             expect(notebook_adapter).to receive(:sleep).ordered
           end
 

--- a/timex_datalink_client.gemspec
+++ b/timex_datalink_client.gemspec
@@ -104,5 +104,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activemodel", "~> 7.0.4"
   s.add_dependency "crc", "~> 0.4.2"
   s.add_dependency "mdb", "~> 0.5.0"
-  s.add_dependency "serialport", "~> 1.3.2"
+  s.add_dependency "uart", "~> 1.0.0"
 end


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/329!

This PR replaces the serialport gem with uart gem.

The serialport gem currently [does not build on Windows via WSL](https://github.com/synthead/timex_datalink_client/issues/329), and in attempting to build this gem on my own machine, I also get:

```
posix_serialport_impl.c:113:13: error: passing argument 1 of ‘rb_obj_setup’ makes integer from pointer without a cast [-Wint-conversion]
  113 |    OBJSETUP(sp, class, T_FILE);
      |             ^~
      |             |
      |             struct RFile *
```

Stangely, this PR replaces the serialport gem with a uart gem that is 8 years old:

- https://github.com/tenderlove/uart

However, the uart gem is pretty foolproof, with only one file that is 121 lines long, which includes a multi-line comment:

- https://github.com/tenderlove/uart/blob/d3facf9c93dd4705d9e1af86096f6d113b3b2a45/lib/uart.rb

...and strangely, it seems that this gem is still maintained, as an example for a Flipper Zero was added only 11 months ago:

- https://github.com/tenderlove/uart/commit/d3facf9c93dd4705d9e1af86096f6d113b3b2a45

So let's try it!