### PR TITLE
Use "bundle exec" in gemspec CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           bundler-cache: true
       - run: gem build timex_datalink_client.gemspec
       - run: gem install timex_datalink_client-*.gem
-      - run: ruby -e 'require "timex_datalink_client"'
+      - run: bundle exec ruby -e 'require "timex_datalink_client"'
 
   markdownlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_client/issues/333!

This PR uses `bundle exec` with `ruby -e 'require "timex_datalink_client"'` in the `gemspec` CI job.  This ensures that the expected gem versions are loaded when this CI job runs :+1: 

From https://github.com/synthead/timex_datalink_client/issues/333:

> The `gemspec` CI job is defined as:
> 
> https://github.com/synthead/timex_datalink_client/blob/263bffa8a71a0af792c46bea2ae69ab2a015f670/.github/workflows/ci.yml?plain=1#L33-L42
> 
> The last "run" step does not use `bundle exec`, so the gem requirements in `Gemfile.lock` are not honored.  Currently, this causes failures in CI like this one:
> 
> - https://github.com/synthead/timex_datalink_client/actions/runs/13321858323/job/37207940688
> 
> ```
> Run ruby -e 'require "timex_datalink_client"'
> /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:12:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)
> 
>     Logger::Severity.constants.each do |severity|
>           ^^^^^^^^^^
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support/logger_silence.rb:5:in `<top (required)>'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support/logger.rb:3:in `<top (required)>'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support.rb:29:in `<top (required)>'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/activemodel-7.0.8.7/lib/active_model.rb:26:in `<top (required)>'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.3/lib/timex_datalink_client/protocol_1/alarm.rb:3:in `<top (required)>'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/timex_datalink_client-0.12.3/lib/timex_datalink_client.rb:6:in `<top (required)>'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:159:in `require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:159:in `rescue in require'
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:39:in `require'
> 	from -e:1:in `<main>'
> <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- timex_datalink_client (LoadError)
> 	from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
> 	from -e:1:in `<main>'
> Error: Process completed with exit code 1.
> ```
> 
> This 👆 is due to the gem being required without the gem versions set via `bundle exec` 👍 